### PR TITLE
General improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,8 @@ help:
 	@echo "to operate on subset of components. Example: make COMPONENTS=\"gui\" get-sources"
 
 
-get-sources-tgt = $(addsuffix .get-sources,$(filter-out builder,$(COMPONENTS)))
+get-sources-sort = $(BUILDER_PLUGINS) $(filter-out builder $(BUILDER_PLUGINS), $(COMPONENTS))
+get-sources-tgt = $(addsuffix .get-sources, $(get-sources-sort))
 .PHONY: get-sources $(get-sources-tgt)
 $(get-sources-tgt): build-info
 	@REPO=$(@:%.get-sources=$(SRC_DIR)/%) MAKE="$(MAKE)" $(BUILDER_DIR)/scripts/get-sources

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ check_branch = if [ -n "$(1)" -a "0$(CHECK_BRANCH)" -ne 0 ]; then \
 					   exit 1; \
 				   fi; \
 				   popd > /dev/null; \
-			   fi; 
+			   fi;
 
 .EXPORT_ALL_VARIABLES:
 .ONESHELL:
@@ -372,7 +372,7 @@ clean::
 	done;
 
 .PHONY: clean-chroot
-clean-chroot:: 
+clean-chroot::
 	@dists="$(shell ls -d $(BUILDER_DIR)/chroot-*)"; \
 	for dist in $$dists; do \
 	    sudo $(BUILDER_DIR)/scripts/umount_kill.sh "$$dist"; \

--- a/Makefile
+++ b/Makefile
@@ -287,8 +287,7 @@ template-local-%::
 	# some sources can be downloaded and verified during template building
 	# process - e.g. archlinux template
 	export GNUPGHOME="$(BUILDER_DIR)/keyrings/template-$$DIST"
-	mkdir -p "$$GNUPGHOME"
-	chmod 700 "$$GNUPGHOME"
+	mkdir -m 700 -p "$$GNUPGHOME"
 	export DIST NO_SIGN TEMPLATE_FLAVOR TEMPLATE_OPTIONS
 	$(MAKE) -s -C $(SRC_DIR)/linux-template-builder prepare-repo-template || exit 1
 	for repo in $(GIT_REPOS); do \

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ clean-rpms:: clean-installer-rpms
 		sudo rm -rf qubes-packages-mirror-repo/$$dist || true ;\
 	done
 	@echo 'Cleaning up rpms in $(SRC_DIR)/*/pkgs/*/*/*...'; \
-	sudo rm -fr $(SRC_DIR)/*/pkgs/*/*/*.rpm || true; \
+	sudo rm -fr $(SRC_DIR)/*/pkgs/*/*/*.rpm || true;
 
 .PHONY: clean
 clean::

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ COMPONENTS ?= builder
 LINUX_REPO_BASEDIR ?= $(SRC_DIR)/linux-yum/current-release
 INSTALLER_COMPONENT ?= installer-qubes-os
 BACKEND_VMM ?= xen
-KEYRING_DIR_GIT ?= $(PWD)/keyrings/git
+KEYRING_DIR_GIT ?= $(BUILDER_DIR)/keyrings/git
 
 TESTING_DAYS = 7
 

--- a/Makefile
+++ b/Makefile
@@ -826,12 +826,11 @@ build-id::
 
 # TODO: Consider changing umount_kill script to the following:
 # "fuser -kmM" && umount -R
-.PHONY: umount
-umount:
-	-@sudo $(BUILDER_DIR)/scripts/umount_kill.sh "$(BUILDER_DIR)/$(SRC_DIR)/"; \
-	for dist in $(DISTS_ALL); do \
-	    sudo $(BUILDER_DIR)/scripts/umount_kill.sh "$(BUILDER_DIR)/chroot-$$dist"; \
-	done;
+umount-tgt = $(DISTS_ALL:%=chroot-%.umount) $(SRC_DIR).umount
+.PHONY: umount $(umount-tgt)
+$(umount-tgt):
+	@sudo $(BUILDER_DIR)/scripts/umount_kill.sh $(BUILDER_DIR)/$(@:%.umount=%)
+umount: $(umount-tgt)
 
 # Returns variable value
 # Example usage: GET_VAR=DISTS_VM make get-var

--- a/Makefile
+++ b/Makefile
@@ -158,18 +158,12 @@ help:
 	@echo "You can also specify COMPONENTS=\"c1 c2 c3 ...\" on command line"
 	@echo "to operate on subset of components. Example: make COMPONENTS=\"gui\" get-sources"
 
-.PHONY: get-sources
-get-sources:: COMPONENTS := $(filter-out builder $(BUILDER_PLUGINS), $(COMPONENTS))
-get-sources:: COMPONENTS := $(BUILDER_PLUGINS) $(COMPONENTS)
-get-sources:: GIT_REPOS := $(addprefix $(SRC_DIR)/, $(COMPONENTS))
-get-sources:: build-info
-get-sources::
-	@set -a; \
-	SCRIPT_DIR=$(CURDIR)/scripts; \
-	SRC_ROOT=$(CURDIR)/$(SRC_DIR); \
-	for REPO in $(GIT_REPOS); do \
-		$$SCRIPT_DIR/get-sources || exit 1; \
-	done
+
+get-sources-tgt = $(addsuffix .get-sources,$(filter-out builder,$(COMPONENTS)))
+.PHONY: get-sources $(get-sources-tgt)
+$(get-sources-tgt): build-info
+	@REPO=$(@:%.get-sources=$(SRC_DIR)/%) MAKE="$(MAKE)" $(BUILDER_DIR)/scripts/get-sources
+get-sources: $(get-sources-tgt)
 
 .PHONY: check-depend
 check-depend:

--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,9 @@ template-local-%::
 	TEMPLATE_OPTIONS="$${dist_array[@]:2}"
 	plugins_var="BUILDER_PLUGINS_$$DIST"
 	BUILDER_PLUGINS_COMBINED="$(BUILDER_PLUGINS) $${!plugins_var}"
-	BUILDER_PLUGINS_DIRS=`for d in $$BUILDER_PLUGINS_COMBINED; do echo -n " $(CURDIR)/$(SRC_DIR)/$$d"; done`
+	BUILDER_PLUGINS_DIRS=`for d in $$BUILDER_PLUGINS_COMBINED; do echo -n " $(BUILDER_DIR)/$(SRC_DIR)/$$d"; done`
 	export BUILDER_PLUGINS_DIRS
-	CACHEDIR=$(CURDIR)/cache/$$DIST
+	CACHEDIR=$(BUILDER_DIR)/cache/$$DIST
 	export CACHEDIR
 	MAKE_TARGET=rpms
 	if [ "0$(TEMPLATE_ROOT_IMG_ONLY)" -eq "1" ]; then
@@ -285,7 +285,7 @@ template-local-%::
 
 	# some sources can be downloaded and verified during template building
 	# process - e.g. archlinux template
-	export GNUPGHOME="$(CURDIR)/keyrings/template-$$DIST"
+	export GNUPGHOME="$(BUILDER_DIR)/keyrings/template-$$DIST"
 	mkdir -p "$$GNUPGHOME"
 	chmod 700 "$$GNUPGHOME"
 	export DIST NO_SIGN TEMPLATE_FLAVOR TEMPLATE_OPTIONS
@@ -295,7 +295,7 @@ template-local-%::
 			$(MAKE) --no-print-directory -f Makefile.generic \
 				PACKAGE_SET=vm \
 				COMPONENT=`basename $$repo` \
-				UPDATE_REPO=$(CURDIR)/$(SRC_DIR)/linux-template-builder/pkgs-for-template/$$DIST \
+				UPDATE_REPO=$(BUILDER_DIR)/$(SRC_DIR)/linux-template-builder/pkgs-for-template/$$DIST \
 				update-repo || exit 1
 		elif $(MAKE) -C $$repo -n update-repo-template > /dev/null 2> /dev/null; then
 			$(MAKE) -s -C $$repo update-repo-template || exit 1
@@ -426,7 +426,7 @@ iso:
 				PACKAGE_SET=dom0 \
 				DIST=$(DIST_DOM0) \
 				COMPONENT=`basename $$repo` \
-				UPDATE_REPO=$(CURDIR)/$(SRC_DIR)/$(INSTALLER_COMPONENT)/yum/qubes-dom0 \
+				UPDATE_REPO=$(BUILDER_DIR)/$(SRC_DIR)/$(INSTALLER_COMPONENT)/yum/qubes-dom0 \
 				update-repo || exit 1
 	    elif $(MAKE) -s -C $$repo -n update-repo-installer > /dev/null 2> /dev/null; then \
 	        if ! $(MAKE) -s -C $$repo update-repo-installer ; then \
@@ -436,7 +436,7 @@ iso:
 	    fi; \
 	done
 	@for DIST in $(DISTS_VM); do \
-		if ! DIST=$$DIST UPDATE_REPO=$(CURDIR)/$(SRC_DIR)/$(INSTALLER_COMPONENT)/yum/qubes-dom0 \
+		if ! DIST=$$DIST UPDATE_REPO=$(BUILDER_DIR)/$(SRC_DIR)/$(INSTALLER_COMPONENT)/yum/qubes-dom0 \
 			$(MAKE) -s -C $(SRC_DIR)/linux-template-builder update-repo-installer ; then \
 				echo "make update-repo-installer failed for template dist=$$DIST"; \
 				exit 1; \
@@ -578,8 +578,8 @@ push:
 SHELL = /bin/bash
 -prepare-merge:
 	@set -a; \
-	SCRIPT_DIR=$(CURDIR)/scripts; \
-	SRC_ROOT=$(CURDIR)/$(SRC_DIR); \
+	SCRIPT_DIR=$(BUILDER_DIR)/scripts; \
+	SRC_ROOT=$(BUILDER_DIR)/$(SRC_DIR); \
 	FETCH_ONLY=1; \
 	IGNORE_MISSING=1; \
 	REPOS="$(GIT_REPOS)"; \
@@ -689,8 +689,8 @@ internal-update-repo-%:
 			COMPONENT=`basename $(REPO)` \
 			SNAPSHOT_REPO=$(SNAPSHOT_REPO) \
 			TARGET_REPO=$(TARGET_REPO) \
-			UPDATE_REPO=$(CURDIR)/$$repo_basedir/$(TARGET_REPO)/$(PACKAGE_SET)/$(DIST) \
-			SNAPSHOT_FILE=$(CURDIR)/repo-latest-snapshot/$(SNAPSHOT_REPO)-$(PACKAGE_SET)-$(DIST)-`basename $(REPO)` \
+			UPDATE_REPO=$(BUILDER_DIR)/$$repo_basedir/$(TARGET_REPO)/$(PACKAGE_SET)/$(DIST) \
+			SNAPSHOT_FILE=$(BUILDER_DIR)/repo-latest-snapshot/$(SNAPSHOT_REPO)-$(PACKAGE_SET)-$(DIST)-`basename $(REPO)` \
 			$(MAKE_TARGET) || exit 1; \
 	elif $(MAKE) -C $(REPO) -n update-repo-$(TARGET_REPO) >/dev/null 2>/dev/null; then \
 		echo "Updating $(REPO)... "; \
@@ -743,7 +743,7 @@ check-release-status-%:
 			continue; \
 		fi
 		echo -n "$$C: "; \
-		$(CURDIR)/scripts/check-release-status-for-component --color "$$C" "$(PACKAGE_SET)" "$(DIST)"
+		$(BUILDER_DIR)/scripts/check-release-status-for-component --color "$$C" "$(PACKAGE_SET)" "$(DIST)"
 	done; \
 
 windows-image:
@@ -756,7 +756,7 @@ windows-image-extract:
 		[ $$REPO == '.' ] && break; \
 		if [ -r $$REPO/Makefile.builder ]; then \
 			$(MAKE) -s -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 \
-				WINDOWS_IMAGE_DIR=$(CURDIR)/mnt \
+				WINDOWS_IMAGE_DIR=$(BUILDER_DIR)/mnt \
 				COMPONENT=`basename $$REPO` \
 				DIST=dummy \
 				windows-image-extract; \

--- a/Makefile
+++ b/Makefile
@@ -362,8 +362,6 @@ clean::
 			for DIST in $(DISTS_VM_NO_FLAVOR); do \
 				DIST=$$DIST $(MAKE) -s -C $$REPO clean || exit 1; \
 			done ;\
-		elif [ $$REPO == "$(SRC_DIR)/yum" ]; then \
-			echo ;\
 		elif [ $$REPO == "." ]; then \
 			echo ;\
 		else \

--- a/scripts/build_full_template_in_dispvm
+++ b/scripts/build_full_template_in_dispvm
@@ -39,7 +39,7 @@ parseConfigLocation() {
             echo \$fpr:6: | gpg --import-ownertrust;
         done;
         gpg --import builder-conf-repo-key.asc;
-        SCRIPT_DIR=\$PWD GIT_URL=\"$TEMPLATE_CONF_URL\" REPO=/tmp/builder-conf-repo BRANCH=\"$TEMPLATE_CONF_BRANCH\" ./get-sources.sh || exit 1;
+        GIT_URL=\"$TEMPLATE_CONF_URL\" REPO=/tmp/builder-conf-repo BRANCH=\"$TEMPLATE_CONF_BRANCH\" ./scripts/get-sources || exit 1;
         rm -rf \$GNUPGHOME; unset GNUPGHOME;
         cp /tmp/builder-conf-repo/config/builder.conf ./builder.conf;
         "

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -77,7 +77,7 @@ fi
 
 if [ "$verify" == "true" ]; then
     echo "--> Verifying tags..."
-    $SCRIPT_DIR/verify-git-tag $REPO $VERIFY_REF || exit 1
+    $(dirname $0)/verify-git-tag $REPO $VERIFY_REF || exit 1
 fi
 
 if [ "$FETCH_ONLY" != "1" ]; then

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -102,14 +102,16 @@ echo "--> Merging..."
 [ "$VERIFY_REF" == "FETCH_HEAD" ] && ( cd $REPO; git merge --commit -q FETCH_HEAD; )
 
 # For additionally download sources
-if make -C $REPO -n get-sources verify-sources > /dev/null 2> /dev/null; then
+MAKE=${MAKE:-make}
+
+if $MAKE -C $REPO -n get-sources verify-sources > /dev/null 2> /dev/null; then
     export GNUPGHOME="$PWD/keyrings/$COMPONENT"
     mkdir -p "$GNUPGHOME"
     chmod 700 "$GNUPGHOME"
     echo "--> Downloading additional sources for $COMPONENT..."
-    make --quiet -C $REPO get-sources
+    $MAKE --quiet -C $REPO get-sources
     echo "--> Verifying the sources..."
-    make --quiet -C $REPO verify-sources
+    $MAKE --quiet -C $REPO verify-sources
 fi
 fi
 echo

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -108,8 +108,7 @@ MAKE=${MAKE:-make}
 
 if $MAKE -C $REPO -n get-sources verify-sources > /dev/null 2> /dev/null; then
     export GNUPGHOME="$PWD/keyrings/$COMPONENT"
-    mkdir -p "$GNUPGHOME"
-    chmod 700 "$GNUPGHOME"
+    mkdir -m 700 -p "$GNUPGHOME"
     echo "--> Downloading additional sources for $COMPONENT..."
     $MAKE --quiet -C $REPO get-sources
     echo "--> Verifying the sources..."

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -50,8 +50,9 @@ echo "-> Updating sources for $COMPONENT..."
 echo "--> Fetching from $GIT_URL $BRANCH..."
 if [ "$REPO" == "." -o -d $REPO -a "$CLEAN" != '1' ]; then
     cd $REPO
-    git fetch -q $GIT_URL --tags $BRANCH || \
-        { [ 0$IGNORE_MISSING -eq 1 ] && exit 0 || exit 1; }
+    if ! git fetch -q $GIT_URL --tags $BRANCH; then
+        if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
+    fi
     VERIFY_REF=FETCH_HEAD
     cd -
 else

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -100,8 +100,10 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" -o "$VERIFY_REF" == "HEAD" ]; then
     popd &> /dev/null
 fi
 
-echo "--> Merging..."
-[ "$VERIFY_REF" == "FETCH_HEAD" ] && ( cd $REPO; git merge --commit -q FETCH_HEAD; )
+if [ "$VERIFY_REF" == "FETCH_HEAD" ]; then
+    echo "--> Merging..."
+    cd $REPO && git merge --commit -q FETCH_HEAD
+fi
 
 # For additionally download sources
 MAKE=${MAKE:-make}

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -80,7 +80,9 @@ if [ "$verify" == "true" ]; then
     $(dirname $0)/verify-git-tag $REPO $VERIFY_REF || exit 1
 fi
 
-if [ "$FETCH_ONLY" != "1" ]; then
+if [ "$FETCH_ONLY" == "1" ]; then
+    exit 0
+fi
 
 CURRENT_BRANCH=`cd $REPO; git branch | sed -n -e 's/^\* \(.*\)/\1/p'`
 if [ "$CURRENT_BRANCH" != "$BRANCH" -o "$VERIFY_REF" == "HEAD" ]; then
@@ -113,5 +115,5 @@ if $MAKE -C $REPO -n get-sources verify-sources > /dev/null 2> /dev/null; then
     echo "--> Verifying the sources..."
     $MAKE --quiet -C $REPO verify-sources
 fi
-fi
+
 echo

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -54,7 +54,7 @@ if [ "$REPO" == "." -o -d $REPO -a "$CLEAN" != '1' ]; then
         if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
     fi
     VERIFY_REF=FETCH_HEAD
-    cd -
+    cd - >/dev/null
 else
     rm -rf $REPO
     git clone -n -q -b $BRANCH $GIT_URL $REPO

--- a/scripts/umount_kill.sh
+++ b/scripts/umount_kill.sh
@@ -25,7 +25,8 @@
 # $1 = full path to mount; 
 # $2 = if set will not umount; only kill processes in mount
 umount_kill() {
-    MOUNTDIR="$1"
+    local MOUNTDIR="$1"
+    local PROMPT_SHOWN=""
 
     # We need absolute paths here so we don't kill everything
     if ! [[ "$MOUNTDIR" = /* ]]; then
@@ -36,9 +37,13 @@ umount_kill() {
     # since we are doing an exact string match on the path
     MOUNTDIR=$(echo "$MOUNTDIR" | sed s#//*#/#g)
 
-    echo "-> Attempting to kill any processes still running in '$MOUNTDIR' before un-mounting"
     for dir in $(grep "$MOUNTDIR" /proc/mounts | cut -f2 -d" " | sort -r | grep "^$MOUNTDIR")
     do
+        if [[ -z $PROMPT_SHOWN ]]; then
+            echo "-> Attempting to kill any processes still running in '$MOUNTDIR' before un-mounting"
+            PROMPT_SHOWN="yes"
+        fi
+
         sudo lsof "$dir" 2> /dev/null | \
             grep "$dir" | \
             tail -n +2 | \


### PR DESCRIPTION
A trial balloon of changes to gauge the reaction. The goal is to eventually move to more idiomatic use of make to express more dependencies and to try to remove the large bits of shell embedded in the makefiles.

The changes to the get-sources and umount targets are examples of this style, where we use make targets to express subtasks instead of fighting make to export variables and hard coding our own iteration in shell.