### PR TITLE
Add "show" target to view commit regardless of repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ help:
 	@echo "make check-depend     -- check for build dependencies ($(DEPENDENCIES))"
 	@echo "make install-deps     -- install missing build dependencies ($(DEPENDENCIES))"
 	@echo "make diff             -- show diffs for any uncommitted changes"
+	@echo "make show REF=git_ref -- show git object git_ref regardless of what repo it's in"
 	@echo "make grep RE=regexp   -- grep for regexp in all components"
 	@echo "make push             -- do git push for all repos, including tags"
 	@echo "make show-vtags       -- list components version tags (only when HEAD have such) and branches"
@@ -482,6 +483,18 @@ diff:
 		fi; \
 	    popd > /dev/null; \
 	done
+
+show:
+	@if [ -n "$$REF" ]; then \
+		for REPO in $(GIT_REPOS); do \
+			pushd $$REPO > /dev/null; \
+			git show $(REF) 2>/dev/null && \
+			echo $(REF) in $$REPO; \
+			popd > /dev/null; \
+		done; \
+	else \
+		echo "Error: show target needs REF= set" >&2; \
+	fi
 
 grep-tgt = $(GIT_REPOS:$(SRC_DIR)/%=%.grep)
 RE ?= $(filter-out grep $(grep-tgt), $(MAKECMDGOALS))


### PR DESCRIPTION
Useful in conjunction with show-unmerged, and when coming across commit hashes on mailing list archives.