### PR TITLE
Allow setting component specific CC, CFLAGS, LDFLAGS from conf file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ $(filter-out qubes-dom0, $(COMPONENTS:%=%-dom0)) : %-dom0 : check-depend
 	@$(call check_branch,$*)
 ifneq ($(DIST_DOM0),)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
-		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* all || exit 1; \
+		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* COMPONENT_CC=$(CC_$*) COMPONENT_CFLAGS=$(CFLAGS_$*) COMPONENT_LDFLAGS=$(LDFLAGS_$*) all || exit 1; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-dom0 2> /dev/null`" ]; then \
 	    MAKE_TARGET="rpms-dom0" ./scripts/build $(DIST_DOM0) $* || exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -839,6 +839,10 @@ build-info::
 	@$(call _info, $(text), TEMPLATE_FLAVOR_DIR,  $(TEMPLATE_FLAVOR_DIR), $(_ORIGINAL_TEMPLATE_FLAVOR_DIR))
 	@$(call _info, $(text), TEMPLATE_ALIAS,  $(TEMPLATE_ALIAS), $(_ORIGINAL_TEMPLATE_ALIAS))
 	@$(call _info, $(text), TEMPLATE_LABEL,  $(TEMPLATE_LABEL), $(_ORIGINAL_TEMPLATE_LABEL))
+	@for component in $(COMPONENTS); do \
+		component_env_var=`$(MAKE) -s get-var GET_VAR=ENV_$${component//-/_}`; \
+		if [ ! -z "$$component_env_var" ]; then $(call _info, $(text), ENV_$${component//-/_}, $${component_env_var}, ""); fi; \
+	done
 else
 build-info::;
 endif

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifdef GIT_SUBDIR
 endif
 
 # checking for make from Makefile is pointless
-DEPENDENCIES ?= git rpmdevtools rpm-build createrepo python-sh wget
+DEPENDENCIES ?= git rpmdevtools rpm-build createrepo python2-sh wget
 
 ifneq (1,$(NO_SIGN))
   DEPENDENCIES += rpm-sign

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(filter-out qubes-vm, $(COMPONENTS:%=%-vm)) : %-vm : check-depend
 	@$(call check_branch,$*)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
 		for DIST in $(DISTS_VM_NO_FLAVOR); do \
-			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* COMPONENT_CC=$(CC_$*) COMPONENT_CFLAGS=$(CFLAGS_$*) -f Makefile.generic all || exit 1; \
+			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* ENV_COMPONENT=$(ENV_$*) -f Makefile.generic all || exit 1; \
 		done; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-vm 2> /dev/null`" ]; then \
 	    for DIST in $(DISTS_VM_NO_FLAVOR); do \
@@ -221,7 +221,7 @@ $(filter-out qubes-dom0, $(COMPONENTS:%=%-dom0)) : %-dom0 : check-depend
 	@$(call check_branch,$*)
 ifneq ($(DIST_DOM0),)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
-		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* COMPONENT_CC=$(CC_$*) COMPONENT_CFLAGS=$(CFLAGS_$*) COMPONENT_LDFLAGS=$(LDFLAGS_$*) all || exit 1; \
+		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* ENV_COMPONENT=$(ENV_$*) all || exit 1; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-dom0 2> /dev/null`" ]; then \
 	    MAKE_TARGET="rpms-dom0" ./scripts/build $(DIST_DOM0) $* || exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(filter-out qubes-vm, $(COMPONENTS:%=%-vm)) : %-vm : check-depend
 	@$(call check_branch,$*)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
 		for DIST in $(DISTS_VM_NO_FLAVOR); do \
-			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* -f Makefile.generic all || exit 1; \
+			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* COMPONENT_CC=$(CC_$*) COMPONENT_CFLAGS=$(CFLAGS_$*) -f Makefile.generic all || exit 1; \
 		done; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-vm 2> /dev/null`" ]; then \
 	    for DIST in $(DISTS_VM_NO_FLAVOR); do \

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(filter-out qubes-vm, $(COMPONENTS:%=%-vm)) : %-vm : check-depend
 	@$(call check_branch,$*)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
 		for DIST in $(DISTS_VM_NO_FLAVOR); do \
-			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* ENV_COMPONENT=$(ENV_$*) -f Makefile.generic all || exit 1; \
+			$(MAKE) --no-print-directory DIST=$$DIST PACKAGE_SET=vm COMPONENT=$* ENV_COMPONENT=$(ENV_$(subst -,_,$*)) -f Makefile.generic all || exit 1; \
 		done; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-vm 2> /dev/null`" ]; then \
 	    for DIST in $(DISTS_VM_NO_FLAVOR); do \
@@ -221,7 +221,7 @@ $(filter-out qubes-dom0, $(COMPONENTS:%=%-dom0)) : %-dom0 : check-depend
 	@$(call check_branch,$*)
 ifneq ($(DIST_DOM0),)
 	@if [ -r $(SRC_DIR)/$*/Makefile.builder ]; then \
-		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* ENV_COMPONENT=$(ENV_$*) all || exit 1; \
+		$(MAKE) -f Makefile.generic DIST=$(DIST_DOM0) PACKAGE_SET=dom0 COMPONENT=$* ENV_COMPONENT=$(ENV_$(subst -,_,$*)) all || exit 1; \
 	elif [ -n "`$(MAKE) -n -s -C $(SRC_DIR)/$* rpms-dom0 2> /dev/null`" ]; then \
 	    MAKE_TARGET="rpms-dom0" ./scripts/build $(DIST_DOM0) $* || exit 1; \
 	fi

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -47,7 +47,7 @@ BUILD_LOG="build-logs/$(COMPONENT)-$(PACKAGE_SET)-$(DIST).log"
 
 # environment variables for build process (inside of chroot)
 
-CHROOT_ENV = BACKEND_VMM=$(BACKEND_VMM) CC=$(COMPONENT_CC) CFLAGS=$(COMPONENT_CFLAGS) LDFLAGS=$(COMPONENT_LDFLAGS)
+CHROOT_ENV = BACKEND_VMM=$(BACKEND_VMM) $(ENV_COMPONENT)
 
 # default value
 ifndef MIN_AGE

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -46,7 +46,8 @@ CACHEDIR = $(PWD)/cache/$(DIST)
 BUILD_LOG="build-logs/$(COMPONENT)-$(PACKAGE_SET)-$(DIST).log"
 
 # environment variables for build process (inside of chroot)
-CHROOT_ENV = BACKEND_VMM=$(BACKEND_VMM)
+
+CHROOT_ENV = BACKEND_VMM=$(BACKEND_VMM) CC=$(COMPONENT_CC) CFLAGS=$(COMPONENT_CFLAGS) LDFLAGS=$(COMPONENT_LDFLAGS)
 
 # default value
 ifndef MIN_AGE

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -54,6 +54,27 @@ Here you specify what you want to build. See example configs for sensible
 lists. The order of components is important - it should reflect build
 dependencies, otherwise build would fail.
 
+### CC_`component`
+> Default: Value set in Makefile of the component
+
+Custom component specific compiler
+
+Example:
+CC_gui-daemon=clang
+
+### CFLAGS_`component`
+> Default: Value set in Makefile of the component
+
+Custom component specific compiler flags
+
+Example:
+CFLAGS_gui-daemon=-fstack-protector-strong
+
+### LDFLAGS_`component`
+> Default: Value set in Makefile of the component
+
+Custom component specific linker flags
+
 ### LINUX_INSTALLER_MULTIPLE_KERNELS
 > Default: "no"
 

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -54,26 +54,16 @@ Here you specify what you want to build. See example configs for sensible
 lists. The order of components is important - it should reflect build
 dependencies, otherwise build would fail.
 
-### CC_`component`
-> Default: Value set in Makefile of the component
+### ENV_`component`
+> Default: None
 
-Custom component specific compiler
+Specify environment variables for component build
 
-Example:
-CC_gui-daemon=clang
+For example:
+ENV_gui-daemon = "\
+    CC=clang \
+    CFLAGS=-fstack-protector-strong"
 
-### CFLAGS_`component`
-> Default: Value set in Makefile of the component
-
-Custom component specific compiler flags
-
-Example:
-CFLAGS_gui-daemon=-fstack-protector-strong
-
-### LDFLAGS_`component`
-> Default: Value set in Makefile of the component
-
-Custom component specific linker flags
 
 ### LINUX_INSTALLER_MULTIPLE_KERNELS
 > Default: "no"

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -57,12 +57,14 @@ dependencies, otherwise build would fail.
 ### ENV_`component`
 > Default: None
 
-Specify environment variables for component build
+Per component environment variables while building.
+Replace '-' with '_' in component name
+Spaces and newlines have to be escaped.
 
 For example:
-ENV_gui-daemon = "\
+ENV_gui_daemon = "\
     CC=clang \
-    CFLAGS=-fstack-protector-strong"
+    CFLAGS=-fstack-protector-strong\ -Wall"
 
 
 ### LINUX_INSTALLER_MULTIPLE_KERNELS


### PR DESCRIPTION
This will allow setting component specific:

* CC: In many of the qubes components, `CC=gcc` has been hardcoded in the Makefiles ([example](https://github.com/QubesOS/qubes-gui-daemon/blob/master/gui-daemon/Makefile#L22)). However, in order to build with other compiler toolchains like clang, with the added advantage of its hardening protection and sanitizer flags along with better static analysis, we should allow setting it from the builder.conf file itself.([example](https://gist.github.com/paraschetal/56161d058f5542ba6961178facbc527f#file-qubes-chroot-env-builder-conf-L30))

* CFLAGS: This will make it easy to set protection flags while building the components and help fixing issues like [this](https://github.com/QubesOS/qubes-issues/issues/2259). Also, with CC_`component` set as clang, we will easily be able to use sanitizer flags while building which will help detecting bugs while testing/fuzzing without having to modify the component's Makefile.

* LDFLAGS: Setting component specific LDFLAGS from the configuration file itself will help for things like statically linking (which is [required by oss-fuzz](https://github.com/google/oss-fuzz/issues/25) btw).

While building a couple of components under clang, using a configuration file like [this](https://gist.githubusercontent.com/paraschetal/56161d058f5542ba6961178facbc527f/raw/30864623aaf08be0fb30975b2bc22e1c7c9a54f5/qubes-chroot-env-builder.conf),  qubes-builder has been able to already detect an errors like:

```
...
+ make dom0
(cd gui-daemon; make)
make[1]: Entering directory '/home/user/qubes-src/gui-daemon/gui-daemon'
clang -fstack-protector-strong -I../include/ -g -O2 -Wall -Wextra -Werror -fPIC `pkg-config --cflags libconfig` `pkg-config --cflags libnotify` `pkg-config --cflags libpng` `pkg-config --cflags vchan-xen`   -c -o xside.o xside.c
xside.c:2933:13: error: address of array 'g->vmname' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
    if (!g->vmname) {
        ~~~~^~~~~~
1 error generated.
<builtin>: recipe for target 'xside.o' failed
make[1]: *** [xside.o] Error 1
make[1]: Leaving directory '/home/user/qubes-src/gui-daemon/gui-daemon'
...
```

So, the end goal here could be to build all components under clang with all hardening flags, correcting all the compiler warnings, and finally checking the security of the built executables by [checksec.sh](https://github.com/slimm609/checksec.sh).

Once this is merged, we can proceed with changing the Makefiles of the components. I have already had to make some changes like [this](https://github.com/paraschetal/qubes-gui-daemon/commits/fix-hardcoded-CC) on my forks to allow building with clang. Of course, the CC, CFLAGS, LDFLAGS can still be set from the component's Makefile to perhaps override those set from builder.conf, but I don't think we should hardcode them by default since it reduces flexibility and control while building the components.

PS: Building using clang would require it to be installed in the chroot dir. I have therefore added it to qubes-builder-fedora's [build-pkgs-base.list](https://github.com/paraschetal/qubes-builder-fedora/commit/ff6a65920478e5982c83b9c96203bbf3c7e6022f). I'm not sure if this is the best way since it is not _essential_ for a regular build using gcc itself.
Also, I had to change python-sh to python2-sh in the DEPENDENCIES of the Makefile of qubes-builder since the components were [not being built](https://github.com/QubesOS/qubes-issues/issues/2910) otherwise on my fedora-25 VM. I am not sure if this change should be made permanent since it might break the build for other distros.

/cc @jpouellet 