### PR TITLE
In templates.conf only override RELEASE when it is not set.

### DIFF
--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -114,7 +114,7 @@
 # [=setup info start=]
 # [=setup info stop=]
 
-RELEASE := 3.2
+RELEASE ?= 3.2
 
 # SSH_ACCESS is used by `setup` to determine if ssh access mode was selected and
 # will re-write the GIT_BASEURL and GIT_PREFIX variables to use ssh mode.


### PR DESCRIPTION
`whonix.conf` and `debian.conf` define RELEASE and later include `templates.conf`.

Since RELEASE was always set to 3.2 in `templates.conf` the RELEASE defined in `whonix.conf` and `debian.conf` had no effect.

Which made it impossible to build debian and whonix for 4.0 using their configs.