### PR TITLE
Add TEMPLATE_LABEL for Fedora 24 & 25

### DIFF
--- a/example-configs/qubes-os-master.conf
+++ b/example-configs/qubes-os-master.conf
@@ -91,6 +91,8 @@ TEMPLATE_LABEL += fc20:fedora-20
 TEMPLATE_LABEL += fc21:fedora-21
 TEMPLATE_LABEL += fc22:fedora-22
 TEMPLATE_LABEL += fc23:fedora-23
+TEMPLATE_LABEL += fc24:fedora-24
+TEMPLATE_LABEL += fc25:fedora-25
 
 # Uncomment this lines to enable Whonix template build
 #DISTS_VM += whonix-gateway whonix-workstation


### PR DESCRIPTION
Add TEMPLATE_LABEL for Fedora 24 & 25 in the master config. Without this, building the master config leads to a fail in including notably the fedora 25 template in the ISO because PUNGI looks for qubes-template-fedora-25 whereas the built rpm template is named qubes-template-fc25.

Probably the reason of the problem described in https://groups.google.com/forum/#!topic/qubes-devel/Rabq0Vl6qfg.