### PR TITLE
Only remove linux-template-builder if exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,9 @@ clean-builder-tgt = $(DISTS_VM_NO_FLAVOR:%=linux-template-builder.clean.%)
 $(clean-tgt):
 	@-$(MAKE) -s -i -k -C $(SRC_DIR)/$(@:%.clean=% clean)
 $(clean-builder-tgt):
-	@-DIST=$(subst .,,$(suffix $@)) $(MAKE) -s -i -k -C $(SRC_DIR)/linux-template-builder clean
+	if [ -d $(SRC_DIR)/linux-template-builder ]; then
+		@-DIST=$(subst .,,$(suffix $@)) $(MAKE) -s -i -k -C $(SRC_DIR)/linux-template-builder clean
+	fi
 clean:: $(clean-tgt) $(clean-builder-tgt);
 
 clean-chroot-tgt = $(DISTS_ALL:%=chroot-%.clean)


### PR DESCRIPTION
`make clean` fails when `COMPONENTS` list did not contained the `linux-template-builder`