### PR TITLE
use python2-sh as a dependency instead of python-sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and should ensure the following packages are installed:
 * rpm-sign (if signing of build packages is enabled)
 * rpmdevtools
 * make 
-* python-sh
+* python2-sh
 * dialog
 * perl-open
 

--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -324,7 +324,7 @@ DEPENDENCIES += git rpmdevtools rpm-build createrepo
 DEPENDENCIES += debootstrap dpkg-dev
 
 # for ./setup
-DEPENDENCIES += python-sh dialog
+DEPENDENCIES += python2-sh dialog
 
 # Uncomment the the following to enable override.conf include.  Setup will
 # automatically enable it only if an override is available and selected by

--- a/setup
+++ b/setup
@@ -1909,7 +1909,7 @@ def main(argv):  # pylint: disable=W0613
 try:
     import sh
 except ImportError:
-    install_deps(['python-sh'])
+    install_deps(['python2-sh'])
     import sh
 
 if __name__ == '__main__':


### PR DESCRIPTION
Referring to the issue here:
https://github.com/QubesOS/qubes-issues/issues/3038

`python-sh` is not a package on fedora, `python2-sh` is.