### PR TITLE
Fix git tag verification to work with gpg2

### DIFF
--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -44,7 +44,7 @@ verify_tag() {
 	temp_name=$(mktemp -d sig-verify.XXXXXX)
 	git cat-file tag "$1" | sed "/$sig_header/,//d"  > "$temp_name/content"
 	git cat-file tag "$1" | sed -n "/$sig_header/,//p" > "$temp_name/content.asc"
-	gpg --verify --status-fd=1 "$temp_name/content.asc" 2>/dev/null | grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)$'
+	gpg --verify --status-fd=1 "$temp_name/content.asc" 2>/dev/null | grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)'
 	ret=$?
 	rm -r "$temp_name"
 	return $ret


### PR DESCRIPTION
The output of `gpg2 --verify` looks like `[GNUPG:] TRUST_FULLY 0 pgp` so we have to loosen the regex.

This is part of the changes that are needed to run the qubes-builder in archlinux, where there is only gnupg 2.2. I'm not sure if the [other](https://github.com/QubesOS/qubes-builder/commit/7b9ec0dadf653136a5816f3aff8e2d8ede40a67f) [changes](https://github.com/QubesOS/qubes-builder/commit/459439dbcdc66cbf64973edfe36dda7e9b45893f) I made a few weeks ago will be useful to anybody else, so at the moment I'll not make another pull request with them.