### PR TITLE
Use single pager for all of show-unmerged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,7 @@ diff:
 		pushd $$REPO > /dev/null; \
 		git status | grep "^nothing to commit" > /dev/null; \
 		if [ $$? -ne 0 ]; then \
-			(echo -e "Uncommited changes in $$REPO:\n\n"; git diff --color=always) | less -R -; \
+			(echo -e "Uncommited changes in $$REPO:\n\n"; git diff --color=always) | less -RM +Gg; \
 		fi; \
 	    popd > /dev/null; \
 	done
@@ -619,7 +619,7 @@ prepare-merge: -prepare-merge show-unmerged
 
 show-unmerged:
 	@REPOS="$(GIT_REPOS)"; \
-	echo "Changes to be merged:"; \
+	{ echo "Changes to be merged:"; \
 	for REPO in $$REPOS; do \
 		pushd $$REPO > /dev/null; \
 		if [ -n "`git log ..FETCH_HEAD 2>/dev/null`" ]; then \
@@ -632,10 +632,10 @@ show-unmerged:
 			fi; \
 			MERGE_TYPE="$${MERGE_TYPE}`git config --get-color '' 'reset'`"; \
 			echo "> $${REPO#$(SRC_DIR)/} $$MERGE_TYPE: git merge FETCH_HEAD"; \
-			git log --pretty=oneline --abbrev-commit ..FETCH_HEAD; \
+			git log --pretty=oneline --abbrev-commit --color=always ..FETCH_HEAD; \
 		fi; \
 		popd > /dev/null; \
-	done
+	done } | less -RM +Gg
 
 do-merge:
 	@REPOS="$(GIT_REPOS)"; \


### PR DESCRIPTION
If it's been a while since your last merge, then only some repos (those
with more than a screen full of changes) will use a pager, whereas
others will output regularly to stdout and then be immediately hidden by
the pager showing the next screen-full of changes in the next repo. This
means you need to quit several pagers and then scroll up in the terminal
to see the changes. Just having one pager invocation to show all changes
is much friendlier IMO.

Also, use +Gg to make less jump to the bottom (reading in all input)
and then jump back to the top. This has two benefits:
  1. Starts displaying at the top of the screen instead of the line your
     cursor was at when less got invoked.
  2. Immediately shows your position in the file as a percentage instead
     of just absolute offset (because by reading in the whole input it
     now knows how much input there is).