### PR TITLE
Make more sense out of a common mistake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(get-sources-extra-tgt):
 	@REPO=$(@:%.get-sources-extra=$(SRC_DIR)/%) MAKE="$(MAKE)" $(BUILDER_DIR)/scripts/get-sources-extra
 builder.get-sources: build-info
 	@REPO=. MAKE="$(MAKE)" $(BUILDER_DIR)/scripts/get-sources
-get-sources: $(filter builder.get-sources, $(COMPONENTS:%=%.get-sources)) $(get-sources-tgt) get-sources-extra
+get-sources: $(BUILDERCONF) $(filter builder.get-sources, $(COMPONENTS:%=%.get-sources)) $(get-sources-tgt) get-sources-extra
 get-sources-extra: $(get-sources-extra-tgt)
 
 .PHONY: check.rpm check.dpkg check-depend check-depend.rpm check-depend.dpkg


### PR DESCRIPTION
When a user just starts 'make get-sources' they start a github
download that fails.

Show that the real problem is that we require a `builder.conf` file

$ make get-sources
make: *** No rule to make target 'builder.conf', needed by 'get-sources'.  Stop.