### PR TITLE
show-unmerged: Use more natural reading order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,7 +632,7 @@ show-unmerged:
 			fi; \
 			MERGE_TYPE="$${MERGE_TYPE}`git config --get-color '' 'reset'`"; \
 			echo "> $${REPO#$(SRC_DIR)/} $$MERGE_TYPE: git merge FETCH_HEAD"; \
-			git log --pretty=oneline --abbrev-commit --color=always ..FETCH_HEAD; \
+			git log --topo-order --reverse --pretty=oneline --abbrev-commit --color=always ..FETCH_HEAD; \
 		fi; \
 		popd > /dev/null; \
 	done } | less -RM +Gg


### PR DESCRIPTION
--reverse so that you can just keep reading down the list instead of
reading a section title, jumping to the bottom, reading up, then
jumping down to the next section.

--topo-order so that related commits from a merged branch are shown
together rather than intermixed by commit date, which makes it easier
to correctly infer intent from short commit titles lacking context.