### PR TITLE
make downloading faster

### DIFF
--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -58,7 +58,7 @@ if [ "$REPO" == "." -o -d $REPO -a "$CLEAN" != '1' ]; then
     cd - >/dev/null
 else
     rm -rf $REPO
-    if ! git clone -n -q -b $BRANCH $GIT_URL $REPO; then
+    if ! git clone --depth 1 -n -q -b $BRANCH $GIT_URL $REPO; then
         if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
     fi
     VERIFY_REF=HEAD


### PR DESCRIPTION
Use git's option to limit downloads to only the current version.

This will make downloads significantly smaller.

As the majority of users will never want to access history, there
is no reason to download it.
For those that do, they can instruct git to download the rest at
a later time.

edit; a user can later use `git fetch --depth=x` with a larger x to cause more history to be fetched. Devs can also use `git fetch --unshallow` to get all data.