### PR TITLE
Fix building iso when the SHELL is not bash

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -80,10 +80,10 @@ fi
 set +e
 MAKE_CMD="cd /home/user/qubes-src/$COMPONENT; NO_SIGN='$NO_SIGN' make $MAKE_OPTS $MAKE_TARGET"
 if [ $VERBOSE -eq 0 ]; then
-    sudo -E chroot chroot-$DIST su -p -c "$MAKE_CMD" $RUN_AS_USER >$BUILD_LOG 2>&1
+    sudo -E chroot chroot-$DIST su -s /bin/bash -p -c "$MAKE_CMD" $RUN_AS_USER >$BUILD_LOG 2>&1
     BUILD_RETCODE=$?
 else
-    sudo -E chroot chroot-$DIST su -p -c "$MAKE_CMD" $RUN_AS_USER
+    sudo -E chroot chroot-$DIST su -s /bin/bash -p -c "$MAKE_CMD" $RUN_AS_USER
     BUILD_RETCODE=$?
 fi
 if [ $BUILD_RETCODE -gt 0 ]; then


### PR DESCRIPTION
I'm using `zsh` as my user shell and I always had to start bash to build the iso. This patch fixes this