### PR TITLE
Fix checking if build deps are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ get-sources-extra: $(get-sources-extra-tgt)
 check.rpm: $(if $(shell which rpm 2>/dev/null), /bin/true, please.install.rpm.and.try.again);
 check.dpkg: $(if $(shell which dpkg 2>/dev/null), /bin/true, please.install.dpkg.and.try.again);
 check-depend.rpm:
-	@echo "Currently installed dependencies:" && rpm -q $(DEPENDENCIES) || \
+	@echo "Currently installed dependencies:" && rpm -q --whatprovides $(DEPENDENCIES) || \
 		{ echo "ERROR: call 'make install-deps' to install missing dependencies"; exit 1; }
 check-depend.dpkg:
 	@test $$(dpkg -l $(DEPENDENCIES) | tail -n +5 | grep '^i' | wc -l) -eq $(words $(DEPENDENCIES)) || \


### PR DESCRIPTION
Add `--whatprovides` rpm option, to also handle virtual packages listed
in DEPENDENCIES setting. This applies also to packages that wasn't
virtual before, but was renamed/obsoleted and now are provided by
another package (like `pkgconfig`).