### PR TITLE
Add PyYAML to documented dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ and should ensure the following packages are installed:
 * python2-sh
 * dialog
 * perl-open
+* PyYAML
 
 Usually one can install those packages by just issuing:
 
-    $ sudo dnf install git createrepo rpm-build rpm-sign make python2-sh rpmdevtools rpm-sign dialog perl-open perl-Digest-MD5 perl-Digest-SHA
+    $ sudo dnf install git createrepo rpm-build rpm-sign make python2-sh rpmdevtools rpm-sign dialog perl-open PyYAML perl-Digest-MD5 perl-Digest-SHA
     
 for older Fedora or CentOS versions use:
 
-    $ sudo yum install git createrepo rpm-build rpm-sign make python2-sh rpmdevtools rpm-sign dialog perl-open
+    $ sudo yum install git createrepo rpm-build rpm-sign make python2-sh rpmdevtools rpm-sign dialog perl-open PyYAML
 
 Or just install them automatically by issuing:
 


### PR DESCRIPTION
It's needed for several pkgs and also apparently initial builder chroot bootstrap. qubes-doc already documents that it should be installed.