### PR TITLE
minor improvements (default to q4.0 and dependency order)

### DIFF
--- a/.setup.data
+++ b/.setup.data
@@ -1,5 +1,5 @@
 [releases]
-default     : 3.2
+default     : 4.0
 2           : Qubes Release 2.0
 3           : Qubes Release 3.0
 3.1         : Qubes Release 3.1

--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -114,7 +114,7 @@
 # [=setup info start=]
 # [=setup info stop=]
 
-RELEASE ?= 3.2
+RELEASE ?= 4.0
 
 # SSH_ACCESS is used by `setup` to determine if ssh access mode was selected and
 # will re-write the GIT_BASEURL and GIT_PREFIX variables to use ssh mode.

--- a/setup
+++ b/setup
@@ -1203,11 +1203,11 @@ class Wizard(Config):
         ## Choose to build a complete system or templates only
         self.set_template_only()
 
-        ## Enable builders
-        self.set_builders()
-
         ## Select which templates to build (DISTS_VM)
         self.set_dists()
+
+        ## Enable builders
+        self.set_builders()
 
         ## Write builder.conf
         self.write_configuration()


### PR DESCRIPTION
two minor straightforward improvements mostly for people who are not fulltime qdevs:
- change default branch from 3.2 to 4.0 (in all the relevant places i could find)
- change ./setup order to pick dists before builders (allowing to do something like a archlinux template only builder.conf with a single setup pass)

i am semi-tempted to add some automated retries to the fetch-keys-from-keyserver, but that code is mildly annoying (deeply stacked else-try-catchall-exit) and on my first attempts not even 10 auto-retries managed to get the key(s) in first pass.  