### PR TITLE
move mirage-firewall repo from /talex5/ to /mirage/

### DIFF
--- a/example-configs/mirage.conf
+++ b/example-configs/mirage.conf
@@ -43,7 +43,7 @@ TEMPLATE += $(BUILDER_PLUGINS)
 
 GIT_URL_builder_mirage = $(GIT_BASEURL)/marmarek/qubes-builder-mirage.git
 GIT_URL_mirage_ssh_agent = $(GIT_BASEURL)/reynir/qubes-mirage-ssh-agent.git
-GIT_URL_mirage_firewall = $(GIT_BASEURL)/talex5/qubes-mirage-firewall.git
+GIT_URL_mirage_firewall = $(GIT_BASEURL)/mirage/qubes-mirage-firewall.git
 BRANCH_builder_mirage = master
 BRANCH_mirage_ssh_agent = master
 BRANCH_mirage_firewall = master


### PR DESCRIPTION
mfw seems to have officially moved into the mirage account now: https://github.com/mirage/qubes-mirage-firewall/commit/ab88d413c483ac05e72db9e18421c6244a1ea653

(not sure thats a good idea for an unsigned repo to move to a group account, but meh...)