### PR TITLE
install-deps: use createrepo_c instead of createrepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,16 @@ ifdef GIT_SUBDIR
 endif
 
 # checking for make from Makefile is pointless
-DEPENDENCIES ?= git rpmdevtools rpm-build createrepo_c python2-sh wget perl-Digest-MD5 perl-Digest-SHA
+DEPENDENCIES ?= git rpmdevtools rpm-build python2-sh wget perl-Digest-MD5 perl-Digest-SHA
+
+DEPENDENCIES.rpm ?= createrepo_c
+DEPENDENCIES.dpkg ?= createrepo
 
 ifneq (1,$(NO_SIGN))
   DEPENDENCIES += rpm-sign
 endif
+
+DEPENDENCIES += $(DEPENDENCIES.$(PKG_MANAGER))
 
 BUILDER_PLUGINS_DISTS :=
 _dist = $(word 1,$(subst +, ,$(_dist_vm)))

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ endif
 # checking for make from Makefile is pointless
 DEPENDENCIES ?= git rpmdevtools rpm-build python2-sh wget perl-Digest-MD5 perl-Digest-SHA
 
+# we add specific distro dependencies due to not common
+# set of packages available like 'createrepo' and 'createrepo_c'
 DEPENDENCIES.rpm ?= createrepo_c
 DEPENDENCIES.dpkg ?= createrepo
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifdef GIT_SUBDIR
 endif
 
 # checking for make from Makefile is pointless
-DEPENDENCIES ?= git rpmdevtools rpm-build createrepo python2-sh wget perl-Digest-MD5 perl-Digest-SHA
+DEPENDENCIES ?= git rpmdevtools rpm-build createrepo_c python2-sh wget perl-Digest-MD5 perl-Digest-SHA
 
 ifneq (1,$(NO_SIGN))
   DEPENDENCIES += rpm-sign


### PR DESCRIPTION
If there is any reason to not use ```createrepo_c``` instead of ```createrepo```, close the PR but in Fedora 30+, it leads to always downgrading the package ```createrepo_c``` and any update will re-update it...