### PR TITLE
Add commented example builder.conf for kernel-only builds

### DIFF
--- a/example-configs/kernel.conf
+++ b/example-configs/kernel.conf
@@ -1,0 +1,58 @@
+#
+# config sample for kernel-only spot-build
+# also useful as a starting point for minimal builds of other pkgs
+# can also be used as an override.conf
+#
+# minimal steps:
+#  create a disposable buildvm with 10GB of private space
+#    5GB base + 5GB for each kernel version you want to build
+#  $ git clone https://github.com/QubesOS/qubes-builder
+#  $ cd qubes-builder
+#  $ cp example-configs/kernel.conf builder.conf
+#  adjust/customize release/branch/giturl as needed
+#  $ make get-sources
+#  $ make install-deps
+#  adjust/customize contents of qubes-src/linux-kernel
+#   want to up/downgrade? 
+#     adjust "version" (and rerun get-sources)
+#   want to mark your kernel? 
+#     add tag/name to rel 
+#     but make sure it still starts with a digit!
+#   want to add some custom modules that have a Kconfig/Kbuild?
+#     grep for "wireguard" or "u2mfn" for examples
+#       download+verify steps go into "Makefile"
+#       build+install steps go into "kernel.spec.in"
+#       or check custom-interactive mode below
+#   want to change kernel config/options? 
+#     add them to the end of "config-qubes"
+#  $ make qubes
+#  this should take about forever
+#    lists three generated .rpm at the end
+#    transfer these to dom0 and install
+#  want to go custom-interactive?
+#    $ sudo chroot chroot-dom0-fc25 su user
+#    $ cd /home/user/rpmbuild/BUILD/kernel-latest-X.Y.Z/linux-X.Y.Z
+#    this is the kernel tree you just built the rpms from
+#    so you can change+rebuild mods here and 
+#    qvm-copy + insmod them in an appvm that runs your pkgd kernel
+#
+
+# comment these two out for use as override.conf
+RELEASE := 4.0
+include example-configs/qubes-os-r$(RELEASE).conf
+
+# adjust/uncomment these to build from different branches/repos
+# master branch builds kernel-latest pkgs,
+#  bleeding edge and avoids wrecking your stable kernels
+BRANCH_linux_kernel = master
+#GIT_URL_linux_kernel = $(GIT_BASEURL)/QubesOS/qubes-linux-kernel.git
+#NO_CHECK = linux-kernel
+
+# adjust these for building different pkgs/targets
+# you have to manually resolve the dependencies!
+COMPONENTS = linux-kernel builder-rpm
+DISTS_VM = ""
+
+# mostly needed for kernel builds
+USE_QUBES_REPO_VERSION = $(RELEASE)
+


### PR DESCRIPTION
the customization examples are mostly just all the reasons i had for building custom kernels over the last two years. 