### PR TITLE
travis: update to rpm 4.14 from bionic

### DIFF
--- a/scripts/travis-build
+++ b/scripts/travis-build
@@ -104,6 +104,47 @@ EOF
     cd ..
 fi
 
+# another case when trusty used in Travis-CI is too old, rejecting zstd compressed rpms (fc31+)
+if echo "$DISTS_VM$DIST_DOM0" | grep -q "^fc"; then
+    cd cache
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/x/xz-utils/liblzma5_5.2.2-1.3_amd64.deb' -O liblzma5_5.2.2-1.3_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/libz/libzstd/libzstd1_1.3.3+dfsg-2ubuntu1_amd64.deb' -O libzstd1_1.3.3+dfsg-2ubuntu1_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/e/elfutils/libelf1_0.170-0.4_amd64.deb' -O libelf1_0.170-0.4_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/librpmio8_4.14.1+dfsg1-2_amd64.deb' -O librpmio8_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/librpm8_4.14.1+dfsg1-2_amd64.deb' -O librpm8_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/rpm2cpio_4.14.1+dfsg1-2_amd64.deb' -O rpm2cpio_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/debugedit_4.14.1+dfsg1-2_amd64.deb' -O debugedit_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/rpm_4.14.1+dfsg1-2_amd64.deb' -O rpm_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/rpm-common_4.14.1+dfsg1-2_amd64.deb' -O rpm-common_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/e/elfutils/libdw1_0.170-0.4_amd64.deb' -O libdw1_0.170-0.4_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/librpmbuild8_4.14.1+dfsg1-2_amd64.deb' -O librpmbuild8_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/librpmsign8_4.14.1+dfsg1-2_amd64.deb' -O librpmsign8_4.14.1+dfsg1-2_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/universe/r/rpm/python-rpm_4.14.1+dfsg1-2_amd64.deb' -O python-rpm_4.14.1+dfsg1-2_amd64.deb
+# update also related -dev, as needed by some
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/e/elfutils/libelf-dev_0.170-0.4_amd64.deb' -O libelf-dev_0.170-0.4_amd64.deb
+    wget 'http://archive.ubuntu.com/ubuntu/pool/main/x/xz-utils/liblzma-dev_5.2.2-1.3_amd64.deb' -O liblzma-dev_5.2.2-1.3_amd64.deb
+sha256sum -c <<EOF
+3166330950b1b81d3e3d370a7753aeff01d583ed6a68b0d6971ea14989721349  debugedit_4.14.1+dfsg1-2_amd64.deb
+defb1452cc2598ff7af1ee815054002d9f65e71f1239b49195fa1d1cdc8a54da  libdw1_0.170-0.4_amd64.deb
+5602704f613f916d06bbf9d62d93a989e830b0ab3baca22c6d3ccf91792562c8  libelf1_0.170-0.4_amd64.deb
+92704fce1ad9af92d59052705d2e0e258789a1718afeca9c0fb0a0d37112b27a  liblzma5_5.2.2-1.3_amd64.deb
+ad030857d564cad16436b35b5bc19484d3369fcc943fc75fcffe96ecd62fe79e  librpm8_4.14.1+dfsg1-2_amd64.deb
+d4e19cab5c051e6fbd37e6e6a57a8d6fca5dbc1c975d483740b1d7b271a1f29e  librpmbuild8_4.14.1+dfsg1-2_amd64.deb
+7c7b91d0d2ab91685049e2a2dbfe56cd38ea5207453b15415b5e9fdae2857bc2  librpmio8_4.14.1+dfsg1-2_amd64.deb
+ca3312be23af24ed6b11e4f95e854e97f7386cbc039fac0555c3f76d420a6551  librpmsign8_4.14.1+dfsg1-2_amd64.deb
+ca52a957fae55f7499cb2b862fa1955303ca2a9eb6c7d5f463fadb1c48dcdbd7  libzstd1_1.3.3+dfsg-2ubuntu1_amd64.deb
+a8336693c6c162a3643478868ed37a906bf657b846f3058974731f7e25675f9c  rpm-common_4.14.1+dfsg1-2_amd64.deb
+a3274e2a2be547ce88f0c8478fde9f614f52abff914d749ba9659ea5e5caff3c  rpm2cpio_4.14.1+dfsg1-2_amd64.deb
+cf8bd81df60b37c2af9a8bf6218bd2f66c4d2af8dee9f1094d7f3359f80e8e96  rpm_4.14.1+dfsg1-2_amd64.deb
+548297208e93206fce79ed68f198ba95ff4a56efce116aaddb49d832bcb800ba  python-rpm_4.14.1+dfsg1-2_amd64.deb
+d999e65b06e23daf4e1ee59a6b6af208a2d78d5ff2ffee592a92d93393e7617b  libelf-dev_0.170-0.4_amd64.deb
+ad193d59735832f88b37588be487e38034c151ab36736cb9f1bb264d745a9413  liblzma-dev_5.2.2-1.3_amd64.deb
+EOF
+    sudo dpkg -i rpm*.deb librpm*.deb python*rpm*.deb liblzma*deb libzstd*deb debugedit*deb libelf*deb libdw1*deb
+    cd ..
+fi
+
+
 # we need this commit to use pbuilder with stretch+
 # https://salsa.debian.org/pbuilder-team/pbuilder/commit/de914ad814fe51179ef35993c5336b9355e84ccf
 if echo "$DISTS_VM$DIST_DOM0" | grep -qv '^fc'; then


### PR DESCRIPTION
fc31+ use zstd compression, which is available in rpm >= 4.14 only.

QubesOS/qubes-issues#5289