### PR TITLE
add TEMPLATE_ROOT_SIZE=50MiB to mirage example

### DIFF
--- a/example-configs/mirage.conf
+++ b/example-configs/mirage.conf
@@ -41,6 +41,8 @@ TEMPLATE_ONLY ?= 0
 TEMPLATE :=
 TEMPLATE += $(BUILDER_PLUGINS)
 
+TEMPLATE_ROOT_SIZE ?= 50MiB
+
 GIT_URL_builder_mirage = $(GIT_BASEURL)/marmarek/qubes-builder-mirage.git
 GIT_URL_mirage_ssh_agent = $(GIT_BASEURL)/reynir/qubes-mirage-ssh-agent.git
 GIT_URL_mirage_firewall = $(GIT_BASEURL)/mirage/qubes-mirage-firewall.git


### PR DESCRIPTION
50M is still a lot more than currently actualy needed, but already a lot better than 10G.
