### PR TITLE
Check for nodev mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ help:
 	@echo "make clean-all        -- remove any downloaded sources and built packages"
 	@echo "make clean-rpms       -- remove any built packages"
 	@echo "make clean-chroot     -- remove all chroot directories"
+	@echo "make remount          -- remount current filesystem with dev option"
 	@echo "make mostlyclean      -- remove built packages and built templates"
 	@echo "make distclean        -- remove all files and directories built or added"
 	@echo "make check            -- check for any uncommited changes and unsigned tags"
@@ -444,6 +445,10 @@ clean-chroot-tgt = $(DISTS_ALL:%=chroot-%.clean)
 $(clean-chroot-tgt): %.clean : %.umount
 	@sudo rm -rf $(BUILDER_DIR)/$(@:%.clean=%)
 clean-chroot: $(clean-chroot-tgt)
+
+.PHONY: remount
+remount:
+	@./scripts/remount .
 
 .PHONY: clean-all
 clean-all: clean-chroot clean-rpms clean

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -157,6 +157,17 @@ generic-prepare-chroot:
 		exit 1; \
 	fi
 	@mkdir -p "$(CACHEDIR)"
+	@if ! scripts/test-sane-mount .; then \
+		mountpoint=$$(scripts/find-mount-point .); \
+		echo "*******************************************************************************"; \
+		echo "***                               ERROR                                      ***"; \
+		echo "*** Cannot create chroot because the current filesystem is mounted as nodev. ***"; \
+		echo "*** Build Qubes on a different filesystem, or run 'make remount' to remount  ***"; \
+		echo "*** $$mountpoint with dev option."; \
+		echo "***                                                                          ***"; \
+		echo "*******************************************************************************"; \
+		exit 1; \
+	fi
 
 .PHONY: prepare-chroot
 prepare-chroot: generic-prepare-chroot dist-prepare-chroot

--- a/scripts/find-mount-point
+++ b/scripts/find-mount-point
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 dir"
+    exit 1
+fi
+
+findmnt --target "$1" --raw --output TARGET --first-only | tail -n1 | cut -d' ' -f1

--- a/scripts/remount
+++ b/scripts/remount
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 dir"
+    exit 1
+fi
+
+mountpoint=$($(dirname $0)/find-mount-point "$1")
+set -x
+sudo mount "$mountpoint" -o dev,remount

--- a/scripts/test-sane-mount
+++ b/scripts/test-sane-mount
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+# See check_sane_mount from debootstrap (in /usr/share/debootstrap/functions).
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 dir"
+    exit 1
+fi
+
+if ! sudo mknod "$1/test-dev-null" c 1 3 -m 666 || ! echo test > "$1/test-dev-null"; then
+    rm -f "$1/test-dev-null"
+    exit 1
+fi
+rm -f "$1/test-dev-null"


### PR DESCRIPTION
In Qubes 4.1, we mount /home with nodev option by default. While
this could be worked around by mounting our own devtmpfs under
/dev, debootstrap is going to complain anyway.

Instead, instruct the user to use a different filesystem, and
provide a conveniente alias to remount the current filesystem
with dev option.