### PR TITLE
Add Ubuntu 20.04 LTS (Focal Fossa) support

### DIFF
--- a/.setup.data
+++ b/.setup.data
@@ -45,7 +45,7 @@ id          : builder-debian
 type        : builder
 description : Debian Builder - Contains all Makefiles to build Debian based templates
 require     : None
-require_in  : jessie stretch buster whonix kali xenial bionic
+require_in  : jessie stretch buster whonix kali xenial bionic focal
 
 [builder-archlinux]
 id          : builder-archlinux

--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -229,6 +229,8 @@ ifeq "$(SETUP_MODE)" "1"
   DISTS_VM += xenial+desktop
   DISTS_VM += bionic
   DISTS_VM += bionic+desktop
+  DISTS_VM += focal
+  DISTS_VM += focal+desktop
   DISTS_VM += archlinux
 endif
 


### PR DESCRIPTION
Hi! I started work on focal vm build. Looks like here are few things required to build that version.

First of all debootstrap in Fedora 32 vm template is too old to have focal script. As this script is the same as all the other, its enough to create a link.
```
sudo ln -vsf gutsy /usr/share/debootstrap/scripts/focal
```

Second issue is that `core-agent-linux` depends on package `initscripts` that was removed from focal. It's now a virtual package that is provided by `sysvinit-utils` and `util-linux`. The later agent already depends on.

Last issue is that vm image created has no password-less root login enabled. I didn't debug this issue yet.

This pull request contains changes related to this repository. I will create pull request for each other repo soon.