### PR TITLE
Second attempt for mitigating signature vulnerability.

### DIFF
--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -54,7 +54,13 @@ else
 fi
 
 verify_tag() {
-    git verify-tag --raw "$1" 2>&1 | grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)'
+    content="$(git verify-tag --raw "$1" 2>&1)"
+    newsig_number="$(echo "$content" | grep -o NEWSIG | wc -l)"
+    if [ "$newsig_number" = 1 ] && { echo "$content" | grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)'; }; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 VALID_TAG_FOUND=0


### PR DESCRIPTION
Here, from the @morgny's article, it seems sufficient to count
the number of "NEWSIG" in the raw data. In all cases, as
requested by @marmarek, there should be only just one.