### PR TITLE
Add DNF related for Debian Bullseye

### DIFF
--- a/example-configs/qubes-os-master.conf
+++ b/example-configs/qubes-os-master.conf
@@ -95,6 +95,11 @@ COMPONENTS ?= \
     antievilmaid \
     dummy-psu \
     dummy-backlight \
+    librepo \
+    libcomps \
+    libsolv \
+    libdnf \
+    dnf \
     builder \
     builder-debian \
     builder-rpm

--- a/example-configs/qubes-os-r4.0.conf
+++ b/example-configs/qubes-os-r4.0.conf
@@ -83,6 +83,11 @@ COMPONENTS ?= \
     antievilmaid \
     xscreensaver \
     dist-upgrade \
+    librepo \
+    libcomps \
+    libsolv \
+    libdnf \
+    dnf \
     builder \
     builder-debian \
     builder-rpm


### PR DESCRIPTION
Until `libsolv` has PR merged, we can add it here. It's only a bump release difference between upstream so nothing that could break update later.