### PR TITLE
travis: redirect selected cmd to log

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -47,3 +47,13 @@ prepare_chroot() {
     make get-sources COMPONENTS='$(BUILDER_PLUGINS)'
     make prepare-chroot-$PACKAGE_SET
 }
+
+show_failed_log() {
+    local exit_code=$?
+    local log
+    log="$1"
+    if [ -e "$log" ]; then
+        tail -n 10000 "$log"
+    fi
+    exit $exit_code
+}

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -8,6 +8,8 @@ cd "$(dirname $0)/.."
 # shellcheck source=scripts/common
 . scripts/common
 
+trap 'show_failed_log travis-install.log' 1
+
 packages="$(find qubes-packages-mirror-repo/ -type f -regex '.*\(deb\|rpm\|zst\)$' 2>/dev/null)"
 if [ -z "$packages" ]; then
     echo "Nothing was built, skipping install stage"
@@ -37,7 +39,8 @@ if [ -n "$YUM" ]; then
     done
     PKGS="$(echo "$PKGS" | tr '\n' ' ')"
     if [ -n "${PKGS% }" ]; then
-        sudo chroot "$chroot_dir" bash -c -l "$YUM install --disablerepo=qubes-builder-pkgs -y $PKGS"
+        # shellcheck disable=SC2024
+        sudo chroot "$chroot_dir" bash -c -l "$YUM install --disablerepo=qubes-builder-pkgs -y $PKGS" > travis-install.log 2>&1 || exit 1
     fi 
 fi
 
@@ -50,6 +53,7 @@ if [ "$APT" ]; then
     done
     PKGS="$(echo "$PKGS" | tr '\n' ' ')"
     if [ -n "${PKGS% }" ]; then
-        sudo chroot "$chroot_dir" bash -c -l "DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes DEBIAN_PRIORITY=critical apt-get -o Dpkg::Options::=--force-confnew --yes install $PKGS"
+        # shellcheck disable=SC2024
+        sudo chroot "$chroot_dir" bash -c -l "DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes DEBIAN_PRIORITY=critical apt-get -o Dpkg::Options::=--force-confnew --yes install $PKGS" > travis-install.log 2>&1 || exit 1
     fi
 fi

--- a/scripts/travis-reprotest
+++ b/scripts/travis-reprotest
@@ -8,6 +8,8 @@ cd "$(dirname $0)/.."
 # shellcheck source=scripts/common
 . scripts/common
 
+trap 'show_failed_log travis-reprotest.log' 1
+
 packages="$(find qubes-packages-mirror-repo/ -type f -regex '.*\(deb\|rpm\|zst\)$' 2>/dev/null)"
 if [ -z "$packages" ]; then
     echo "Nothing was built, skipping reproducible stage"
@@ -32,7 +34,8 @@ if [ "$APT" ]; then
     APT_OPTS="-o Dpkg::Options::=--force-confnew --yes"
 
     # install reprotest and devscripts
-    sudo chroot "$chroot_dir" bash -c -l "$APT_ENV apt-get $APT_OPTS install reprotest devscripts"
+    # shellcheck disable=SC2024
+    sudo chroot "$chroot_dir" bash -c -l "$APT_ENV apt-get $APT_OPTS install reprotest devscripts" > travis-reprotest.log 2>&1 || exit 1
     CONTROLS="$(sudo chroot "$chroot_dir" bash -c -l 'find /tmp/qubes-deb -type f -name "*.dsc"')"
 
     for control in $CONTROLS
@@ -45,6 +48,7 @@ if [ "$APT" ]; then
                     "
         # we remove 'domain_host' variation as we execute into a chroot
         # see reprotest manual
-        sudo chroot "$chroot_dir" bash -c -l "reprotest --vary=-domain_host $repro_opts $control"
+        # shellcheck disable=SC2024
+        sudo chroot "$chroot_dir" bash -c -l "reprotest --vary=-domain_host $repro_opts $control" >> travis-reprotest.log 2>&1 || exit 1
     done
 fi


### PR DESCRIPTION
This is for preventing output size limit of Travis.