### PR TITLE
Fix metadata signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -828,6 +828,7 @@ internal-update-repo-templates-%: UPDATE_REPO_SUBDIR = $(TARGET_REPO)
 # and the actual code
 # this is executed for every (DIST,PACKAGE_SET,COMPONENT) combination
 internal-update-repo-%:
+ifeq ($(MAKEREPO),YES)
 	@repo_base_var="LINUX_REPO_$(DIST)_BASEDIR"; \
 	if [ "$(COMPONENT)" = linux-template-builder ]; then \
 		# templates belongs to dom0 repository, even though PACKAGE_SET=vm
@@ -879,9 +880,15 @@ internal-update-repo-%:
 		echo -n "Updating $(REPO)... skipping."; \
 	fi; \
 	echo
+else ifeq ($(MAKEREPO),NO)
+	@true
+else
+	$(error bad value for $$(MAKEREPO))
+endif
 
 # this is executed only once for all update-repo-* target
 post-update-repo-%:
+ifeq ($(UPLOAD),YES)
 	@for dist in $(DIST_DOM0) $(DISTS_VM_NO_FLAVOR); do \
 		repo_base_var="LINUX_REPO_$${dist}_BASEDIR"; \
 		if [ -n "$${!repo_base_var}" ]; then \
@@ -903,6 +910,11 @@ post-update-repo-%:
 		[ -x "$$repo/../update_repo-$*.sh" ] || continue; \
 		(cd $$repo/.. && ./update_repo-$*.sh r$(RELEASE) $$pkgset_dist); \
 	done
+else ifeq ($(UPLOAD),NO)
+	@true
+else
+	$(error bad value for $$(UPLOAD))
+endif
 
 template-name:
 	@for DIST in $(DISTS_VM); do \

--- a/Makefile
+++ b/Makefile
@@ -823,12 +823,15 @@ internal-update-repo-%: UPDATE_REPO_SUBDIR = $(TARGET_REPO)/$(PACKAGE_SET)/$(DIS
 internal-update-repo-%: BUILD_LOG_URL = $(word 2,$(subst =, ,$(filter $(COMPONENT)-$(PACKAGE_SET)-$(DIST)=%,$(BUILD_LOGS_URL))))
 internal-update-repo-%: $(REPO)
 
+MAKEREPO ?= 1
+UPLOAD ?= 1
+
 # for templates skip $(PACKAGE_SET)/$(DIST)
 internal-update-repo-templates-%: UPDATE_REPO_SUBDIR = $(TARGET_REPO)
 # and the actual code
 # this is executed for every (DIST,PACKAGE_SET,COMPONENT) combination
 internal-update-repo-%:
-ifeq ($(MAKEREPO),YES)
+ifeq ($(MAKEREPO),1)
 	@repo_base_var="LINUX_REPO_$(DIST)_BASEDIR"; \
 	if [ "$(COMPONENT)" = linux-template-builder ]; then \
 		# templates belongs to dom0 repository, even though PACKAGE_SET=vm
@@ -880,7 +883,7 @@ ifeq ($(MAKEREPO),YES)
 		echo -n "Updating $(REPO)... skipping."; \
 	fi; \
 	echo
-else ifeq ($(MAKEREPO),NO)
+else ifeq ($(MAKEREPO),0)
 	@true
 else
 	$(error bad value for $$(MAKEREPO))
@@ -888,7 +891,7 @@ endif
 
 # this is executed only once for all update-repo-* target
 post-update-repo-%:
-ifeq ($(UPLOAD),YES)
+ifeq ($(UPLOAD),1)
 	@for dist in $(DIST_DOM0) $(DISTS_VM_NO_FLAVOR); do \
 		repo_base_var="LINUX_REPO_$${dist}_BASEDIR"; \
 		if [ -n "$${!repo_base_var}" ]; then \
@@ -910,7 +913,7 @@ ifeq ($(UPLOAD),YES)
 		[ -x "$$repo/../update_repo-$*.sh" ] || continue; \
 		(cd $$repo/.. && ./update_repo-$*.sh r$(RELEASE) $$pkgset_dist); \
 	done
-else ifeq ($(UPLOAD),NO)
+else ifeq ($(UPLOAD),0)
 	@true
 else
 	$(error bad value for $$(UPLOAD))

--- a/scripts/auto-build
+++ b/scripts/auto-build
@@ -147,6 +147,7 @@ if ! scripts/make-with-log \
         DIST_DOM0="$built_for_dom0" \
         BUILD_LOGS_URL="$build_logs" \
         GIT_URL_${component//-/_}="$git_url" \
+        MAKEREPO=YES UPLOAD=YES \
         sign-all update-repo-current-testing; then
     build_failure $component upload \
         "dom0:$built_for_dom0 vm:$built_for_vm" "$(get_build_log_url)"

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -55,9 +55,20 @@ else
 fi
 
 verify_tag() {
-    content="$(git verify-tag --raw "$1" 2>&1)"
-    newsig_number="$(echo "$content" | grep -o NEWSIG | wc -l)"
-    if [ "$newsig_number" = 1 ] && { echo "$content" | grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)'; }; then
+    local "tag=$1" "expected_hash=$2" hash
+    if ! hash="$(git rev-parse -q --verify "$tag^{commit}")"; then
+        echo "---> Failed to get tag hash">&2
+        return 1
+    elif ! [ "$hash" = "$expected_hash" ]; then
+        printf %s\\n "---> Tag has wrong hash (found $hash, expected $expected_hash)">&2
+        return 1
+    fi
+    content=$(git verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
+    newsig_number=$(printf %s\\n "$content" | grep -c '^\[GNUPG:] NEWSIG') || return 1
+    if [ "$newsig_number" = 1 ] && {
+        printf %s\\n "$content" |
+        grep '^\[GNUPG:] TRUST_\(FULLY\|ULTIMATE\)' >/dev/null
+    }; then
         return 0
     else
         return 1
@@ -65,20 +76,30 @@ verify_tag() {
 }
 
 VALID_TAG_FOUND=0
-for tag in $(git tag --points-at="$REF"); do
-    if verify_tag "$tag"; then
+set -eu
+case $REF in
+(-*) echo 'Refs cannot begin with -'>&2; exit 1;;
+esac
+expected_hash=$(git rev-parse -q --verify "$REF") || exit 1
+if [ "${#expected_hash}" -ne 40 ] && [ "${#expected_hash}" -ne 64 ]; then
+    echo "---> Bad Git hash value; failing" >&2
+    exit 1
+fi
+
+tags="$(git tag "--points-at=$REF")" || exit 1
+for tag in $tags; do
+    tag="refs/tags/$tag"
+    if verify_tag "$tag" "$expected_hash"; then
         VALID_TAG_FOUND=1
-    else
-        if [ "0$VERBOSE" -ge 1 ]; then
-            echo "---> One of signed tag cannot be verified:"
-            git tag -v "$tag"
-        fi
+    elif [ "0${VERBOSE-}" -ge 1 ]; then
+        echo "---> One of signed tag cannot be verified:"
+	git tag -v "$tag"
     fi
 done
 
 if [ "$VALID_TAG_FOUND" -eq 0 ]; then
     echo "No valid signed tag found!"
-    if [ "0$VERBOSE" -eq 0 ]; then
+    if [ "0${VERBOSE-}" -eq 0 ]; then
         if [ -n "$(git describe "$REF")" ]; then
             echo "---> One of invalid tag:"
             git tag -v $(git describe "$REF")


### PR DESCRIPTION
The keys VM refuses to sign anything unless a build log has been
submitted first.  Therefore, we must submit the log of the metadata
build before trying to sign the metadata.

The Makefile hacks are disgusting, but they should at least work.  Qubes
Builder really needs to be rewritten.