### PR TITLE
add libseccomp-devel to mirage deps

### DIFF
--- a/example-configs/mirage.conf
+++ b/example-configs/mirage.conf
@@ -52,7 +52,7 @@ BRANCH_mirage_firewall = master
 NO_CHECK = mirage-ssh-agent mirage-firewall
 
 DEPENDENCIES ?=
-DEPENDENCIES += git rpmdevtools rpm-build createrepo perl-Digest-MD5 perl-Digest-SHA
+DEPENDENCIES += git rpmdevtools rpm-build createrepo perl-Digest-MD5 perl-Digest-SHA libseccomp-devel
 # for ssh-agent
 DEPENDENCIES += gmp gmp-devel
 


### PR DESCRIPTION
i guess longterm these deps should really be in builder-mirage and/or mirage-fw / mirage-sshagent Makefiles.
