### PR TITLE
Call travis-reprotest directly in the host env.

### DIFF
--- a/scripts/travis-reprotest
+++ b/scripts/travis-reprotest
@@ -34,7 +34,8 @@ if [ "$APT" ]; then
     sudo mkdir -p /tmp/qubes-deb
     sudo mount --bind "$builder_repo_dir" /tmp/qubes-deb
 
-    apt-get update
+    # update qubes-builder and Qubes repositories as we brought packages with artifacts
+    sudo apt-get update
 
     # install reprotest and devscripts
     CONTROLS="$(find /tmp/qubes-deb -type f -name "*.dsc")"

--- a/scripts/travis-reprotest
+++ b/scripts/travis-reprotest
@@ -3,7 +3,9 @@
 set -ex
 
 # go to builder main directory
-cd "$(dirname $0)/.."
+scriptdir="$(readlink -f "$(dirname "$0")")"
+builderdir="$(readlink -f "$scriptdir"/..)"
+cd "$builderdir"
 
 # shellcheck source=scripts/common
 . scripts/common
@@ -20,39 +22,29 @@ keep_alive_pid=$!
 
 trap 'exit_travis travis-reprotest.log ${keep_alive_pid}' 0 1
 
-# we handle case where we run reprotest stage separately with build artifacts (e.g. GitlabCI).
-if [ "$1" = prepare-chroot ]; then
-    prepare_chroot
+YUM="$(/usr/bin/which dnf || true)"
+if [ -z "$YUM" ]; then
+    YUM="$(/usr/bin/which yum || true)"
 fi
-
-chroot_dir="$(ls -d chroot-* || :)"
-if [ -z "$chroot_dir" ]; then
-    exit
-fi
-
-YUM="$(get_yum "$chroot_dir")"
-APT="$(get_apt "$chroot_dir")"
+APT="$(/usr/bin/which apt-get || true)"
 
 if [ "$APT" ]; then
-    APT_ENV="DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes DEBIAN_PRIORITY=critical"
-    APT_OPTS="-o Dpkg::Options::=--force-confnew --yes"
+    # copy qubes-builder packages repo to /tmp/qubes-repo
+    builder_repo_dir="$builderdir/qubes-packages-mirror-repo/$([[ -n ${DIST_DOM0} ]] && echo "dom0-${DIST_DOM0}" || echo "vm-${DISTS_VM}")"
+    sudo mkdir -p /tmp/qubes-deb
+    sudo mount --bind "$builder_repo_dir" /tmp/qubes-deb
+
+    apt-get update
 
     # install reprotest and devscripts
-    # shellcheck disable=SC2024
-    sudo chroot "$chroot_dir" bash -c -l "$APT_ENV apt-get $APT_OPTS install reprotest devscripts" > travis-reprotest.log 2>&1 || exit 1
-    CONTROLS="$(sudo chroot "$chroot_dir" bash -c -l 'find /tmp/qubes-deb -type f -name "*.dsc"')"
+    CONTROLS="$(find /tmp/qubes-deb -type f -name "*.dsc")"
 
+    test -c /dev/fuse || mknod -m 666 /dev/fuse c 10 229
     for control in $CONTROLS
-    do
-        # reprotest
-        repro_opts="--testbed-init 'apt-get -y --no-install-recommends install \
-                    disorderfs faketime locales-all sudo util-linux; \
-                    test -c /dev/fuse || mknod -m 666 /dev/fuse c 10 229' \
-                    --testbed-build-pre 'apt-get -y --no-install-recommends build-dep $control' \
-                    "
+    do      
         # we remove 'domain_host' variation as we execute into a chroot
         # see reprotest manual
         # shellcheck disable=SC2024
-        sudo chroot "$chroot_dir" bash -c -l "reprotest --vary=-domain_host $repro_opts $control" >> travis-reprotest.log 2>&1 || exit 1
+        sudo reprotest --vary=-domain_host --testbed-build-pre "apt-get -y --no-install-recommends build-dep $control" "$control" >> travis-reprotest.log 2>&1 || exit 1
     done
 fi


### PR DESCRIPTION
This test is used in CI with a docker based on the underlying distro.

Thanks to Marek for his suggestions.