### PR TITLE
Rely on git’s gpg.minTrustLevel flag

### DIFF
--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -63,16 +63,7 @@ verify_tag() {
         printf %s\\n "---> Tag has wrong hash (found $hash, expected $expected_hash)">&2
         return 1
     fi
-    content=$(git verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
-    newsig_number=$(printf %s\\n "$content" | grep -c '^\[GNUPG:] NEWSIG') || return 1
-    if [ "$newsig_number" = 1 ] && {
-        printf %s\\n "$content" |
-        grep '^\[GNUPG:] TRUST_\(FULLY\|ULTIMATE\)' >/dev/null
-    }; then
-        return 0
-    else
-        return 1
-    fi
+    git -c gpg.minTrustLevel=fully verify-tag -- "$tag" >/dev/null 2>&1
 }
 
 VALID_TAG_FOUND=0


### PR DESCRIPTION
Git supports setting the minimum GPG trust level, which in our case
should be “fully”.  This avoids having to parse the output of GPG
ourselves, and allows us to rely on the parser built-in to Git.