### PR TITLE
Harden get-sources and verify-git-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -703,10 +703,11 @@ prepare-merge-fetch:
 	components_var="REMOTE_COMPONENTS_$${GIT_REMOTE//-/_}"; \
 	[ -n "$${!components_var}" ] && REPOS="`echo $${!components_var} | sed 's@^\| @ $(SRC_DIR)/@g'`"; \
 	for REPO in $$REPOS; do \
-		$$SCRIPT_DIR/get-sources || exit 1; \
+		"$$SCRIPT_DIR/get-sources" || exit 1; \
 	done
 
 prepare-merge: prepare-merge-fetch show-unmerged
+merge: prepare-merge-fetch do-merge
 
 show-unmerged:
 	@REPOS="$(GIT_REPOS)"; \

--- a/Makefile
+++ b/Makefile
@@ -734,9 +734,10 @@ do-merge:
 	components_var="REMOTE_COMPONENTS_$${GIT_REMOTE//-/_}"; \
 	[ -n "$${!components_var}" ] && REPOS="`echo $${!components_var} | sed 's@^\| @ $(SRC_DIR)/@g'`"; \
 	for REPO in $$REPOS; do \
-		git -C $$REPO rev-parse -q --verify FETCH_HEAD >/dev/null || continue; \
+		rev=$$(git -C $$REPO rev-parse -q --verify FETCH_HEAD) || continue; \
+		./scripts/verify-git-tag "$$REPO" "$$rev" || exit 1; \
 		echo "Merging FETCH_HEAD into $$REPO"; \
-		git -C $$REPO merge --ff $(GIT_MERGE_OPTS) --no-edit FETCH_HEAD || exit 1; \
+		git -C $$REPO merge --ff $(GIT_MERGE_OPTS) --no-edit "$$rev" || exit 1; \
 	done
 
 do-merge-versions-only:
@@ -744,10 +745,11 @@ do-merge-versions-only:
 	components_var="REMOTE_COMPONENTS_$${GIT_REMOTE//-/_}"; \
 	[ -n "$${!components_var}" ] && REPOS="`echo $${!components_var} | sed 's@^\| @ $(SRC_DIR)/@g'`"; \
 	for REPO in $$REPOS; do \
-		git -C $$REPO rev-parse -q --verify FETCH_HEAD >/dev/null || continue; \
-		git -C $$REPO tag --points-at FETCH_HEAD | grep -q '^v' || continue; \
+		rev=$$(git -C $$REPO rev-parse -q --verify FETCH_HEAD) || continue; \
+		git -C $$REPO tag --points-at "$$rev" | grep -q '^v' || continue; \
+		./scripts/verify-git-tag "$$REPO" "$$rev" || exit 1; \
 		echo "Merging FETCH_HEAD into $$REPO"; \
-		git -C $$REPO merge --ff $(GIT_MERGE_OPTS) --no-edit FETCH_HEAD || exit 1; \
+		git -C $$REPO merge --ff $(GIT_MERGE_OPTS) --no-edit "$$rev" || exit 1; \
 	done
 
 add-remote:

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -216,17 +216,25 @@ When building 'iso' target, build installation iso.
 When building 'iso' target, build live image. Can be set together with
 `ISO_INSTALLER` to build both.
 
-### NO_CHECK
+### `INSECURE_SKIP_CHECKING`
 > Default: no value
 
-Disable signed tag checking - set "1" to disable verify for everything or
-can be a list of package names separated with spaces
+Disable signed tag checking - set to a list of package names separated with
+spaces.
+
 Example:
-    NO_CHECK=gui-agent-linux linux-template-builder
+    INSECURE_SKIP_CHECKING=gui-agent-linux linux-template-builder
 
 *Do not use this option unless you really understand what you are doing*. If
 you want to handle your private fork, its better to sign the code and import
 your key into keyring pointed by `KEYRING_DIR_GIT` option.
+
+### `LESS_SECURE_ALLOW_SIGNED_COMMITS`
+> Default: no value
+
+Allow signed commits instead of requiring signed tags. This is less secure
+because only commits that have been reviewed are tagged. Set to a list of
+package names separated with spaces.
 
 ### KEYRING_DIR_GIT
 > Default: keyrings/git

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -31,6 +31,14 @@ set -eufo pipefail
 # shellcheck source=scripts/common
 source "$BUILDER_DIR/scripts/common"
 
+if ! [[ "${INSECURE_SKIP_CHECKING=}" =~ ^[A-Za-z0-9\ -]*$ ]]; then
+    echo 'Invalid value for INSECURE_SKIP_CHECKING'>&2
+    exit 1
+elif ! [[ "${LESS_SECURE_SIGNED_COMMITS_SUFFICIENT=}" =~ ^[A-Za-z0-9\ -]*$ ]]; then
+    echo 'Invalid value for LESS_SECURE_SIGNED_COMMITS_SUFFICIENT'>&2
+    exit 1
+fi
+
 [ -n "$REPO" ] && COMPONENT="$(basename "$REPO")"
 
 # Special case for qubes-builder itself
@@ -98,19 +106,36 @@ else
     VERIFY_REF=HEAD fresh_clone=:
 fi
 
-echo "--> Verifying tags..."
 KEYRING_DIR_GIT="$BUILDER_DIR/keyrings/git/${REPO##*/}"
 export KEYRING_DIR_GIT CHECK=signed-tag
-if ! { VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") &&
-    "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; } then
-    # if verfication failed, remove fetched content to make sure we'll not
-    # use it
-    if "$fresh_clone"; then
-        rm -rf "$REPO"
-    else
-        rm -f "$REPO/.git/FETCH_HEAD"
-    fi
+
+verify=true
+if elementIn "$COMPONENT" $INSECURE_SKIP_CHECKING; then
+    verify=false
+elif elementIn "$COMPONENT" $LESS_SECURE_SIGNED_COMMITS_SUFFICIENT; then
+    CHECK=signed-tag-or-commit
+fi
+
+if [ "$verify" = 'false' ]; then
+    echo -e '\033[1;31m--> NOT verifying tags\033[0;0m'
     exit 1
+else
+    if [[ $CHECK = 'signed-tag-or-commit' ]]; then
+        echo "--> Verifying tags or commits..."
+    else
+        echo "--> Verifying tags..."
+    fi
+    if ! { VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") &&
+        "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; } then
+        # if verfication failed, remove fetched content to make sure we'll not
+        # use it
+        if "$fresh_clone"; then
+            rm -rf "$REPO"
+        else
+            rm -f "$REPO/.git/FETCH_HEAD"
+        fi
+        exit 1
+    fi
 fi
 
 if [ "${FETCH_ONLY-}" == "1" ]; then
@@ -136,7 +161,7 @@ fi
 if ! "$fresh_clone"; then
     echo "--> Merging..."
     git -c merge.verifySignatures=no merge --ff-only --commit -q "$VERIFY_REF"
-    if remote=$(exec git rev-parse --symbolic-full-name '@{u}' "$VERIFY_REF") &&
+    if remote=$(exec git rev-parse --symbolic-full-name '@{u}' "$VERIFY_REF" 2>/dev/null) &&
         [[ "$remote" =~ ^refs/remotes/ ]]; then
         git update-ref -- "$remote" "$VERIFY_REF"
     fi

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -130,6 +130,8 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"
         git checkout "$VERIFY_REF" -b $BRANCH || exit 1
     fi
+    remote=$(git rev-parse --symbolic-full-name '@{u}') &&
+    git update-ref -- "$remote" "$VERIFY_REF"
     popd &> /dev/null || exit 1
 fi
 

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -6,7 +6,6 @@
 #  - GIT_SUFFIX - git component dir suffix (default .git)
 #  - COMPONENT - component to clone
 #  - BRANCH - git branch
-#  - NO_CHECK=1 - disable signed tag checking
 #  - CLEAN=1 - remove previous sources (use git up vs git clone)
 #  - FETCH_ONLY=1 - fetch sources but do not merge
 #  - IGNORE_MISSING=1 - exit with code 0 if remote branch doesn't exists
@@ -59,6 +58,8 @@ branch_var="BRANCH_${COMPONENT//-/_}"
 if [ -n "${!branch_var-}" ]; then
     BRANCH="${!branch_var}"
 fi
+
+: "${IGNORE_MISSING=0}"
 
 GIT_OPTIONS=
 if [ "$GIT_CLONE_FAST" = "1" ]; then

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -164,7 +164,7 @@ fi
 if ! "$fresh_clone"; then
     echo "--> Merging..."
     git -c merge.verifySignatures=no merge --ff-only --commit -q "$VERIFY_REF"
-    if remote=$(exec git rev-parse --symbolic-full-name '@{u}' "$VERIFY_REF" 2>/dev/null) &&
+    if false && remote=$(exec git rev-parse --symbolic-full-name '@{u}' "$VERIFY_REF" 2>/dev/null) &&
         [[ "$remote" =~ ^refs/remotes/ ]]; then
         git update-ref -- "$remote" "$VERIFY_REF"
     fi

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -26,8 +26,8 @@ echo "-> Updating sources for $COMPONENT..."
 echo "--> Fetching from $GIT_INFOS..."
 }
 
-set -e
-[ "$DEBUG" = "1" ] && set -x
+set -euo pipefail
+[ "${DEBUG-}" = "1" ] && set -x
 
 # shellcheck source=scripts/common
 source "$BUILDER_DIR/scripts/common"
@@ -43,20 +43,20 @@ source "$BUILDER_DIR/scripts/common"
 
 url_var="GIT_URL_${COMPONENT//-/_}"
 
-if [ -n "$GIT_URL" ]; then
+if [ -n "${GIT_URL-}" ]; then
     GIT_URL="$GIT_URL"
-elif [ -n "${!url_var}" ]; then
+elif [ -n "${!url_var-}" ]; then
     GIT_URL="${!url_var}"
 else
     GIT_URL=$GIT_BASEURL/$GIT_PREFIX$COMPONENT$GIT_SUFFIX
 fi
 
 # Override GIT_URL with GIT_REMOTE if given
-[ -n "$GIT_REMOTE" ] && GIT_URL=$GIT_REMOTE
+[ -n "${GIT_REMOTE-}" ] && GIT_URL=$GIT_REMOTE
 
 branch_var="BRANCH_${COMPONENT//-/_}"
 
-if [ -n "${!branch_var}" ]; then
+if [ -n "${!branch_var-}" ]; then
     BRANCH="${!branch_var}"
 fi
 
@@ -65,80 +65,77 @@ if [ "$GIT_CLONE_FAST" = "1" ]; then
     GIT_OPTIONS+="--depth=1"
 fi
 
-fresh_clone=0
-if [ "$REPO" == "." ] || [ -d "$REPO" ] && [ "$CLEAN" != '1' ]; then
-    cd $REPO
-    if [ "$(git rev-parse --is-shallow-repository)" == "true" ] && [ "$GIT_CLONE_FAST" != "1" ]; then
+if ! [[ "$BRANCH" =~ ^[A-Za-z][A-Za-z0-9._-]+$ ]]; then
+    printf 'Invalid branch %q\n' "$BRANCH"
+    exit 1
+elif ! { [[ "$REPO" = '.' ]] || [[ "$REPO" =~ ^qubes-src/[A-Za-z][A-Za-z0-9-]*$ ]]; }; then
+    printf 'Invalid repository %q\n' "$REPO"
+    exit 1
+fi
+fresh_clone=false
+if [ "$REPO" == "." ] || [ -d "$REPO" ] && [ "${CLEAN-}" != '1' ]; then
+    cd "$REPO"
+    if [ "$GIT_CLONE_FAST" != "1" ] && [ "$(git rev-parse --is-shallow-repository)" == "true" ]; then
         GIT_OPTIONS+="--unshallow"
     fi
     print_headers
-    if ! git fetch $GIT_OPTIONS -q "$GIT_URL" --tags $BRANCH; then
+    if ! git fetch $GIT_OPTIONS -q "$GIT_URL" --tags "$BRANCH"; then
         if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
     fi
-    VERIFY_REF=FETCH_HEAD
+    VERIFY_REF=FETCH_HEAD fresh_clone=false
     # shellcheck disable=SC2103
     cd - >/dev/null
 else
-    rm -rf $REPO
+    rm -rf "$REPO"
     if [ "$(git rev-parse --is-shallow-repository)" == "true" ] && [ "$GIT_CLONE_FAST" != "1" ]; then
         GIT_OPTIONS+="--unshallow"
     fi
     print_headers
-    if ! git clone $GIT_OPTIONS -n -q -b $BRANCH "$GIT_URL" $REPO; then
+    if ! git clone $GIT_OPTIONS -n -q -b $BRANCH "$GIT_URL" "$REPO"; then
         if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
     fi
-    VERIFY_REF=HEAD
-    fresh_clone=1
+    VERIFY_REF=HEAD fresh_clone=:
 fi
 
-verify=true
-if [ "$NO_CHECK" == "1" ] || elementIn "$COMPONENT" ${NO_CHECK[@]}; then
-    echo "--> $COMPONENT has NO_CHECK enabled"
-    echo "--> NOT Verifying tags..."
-    verify=false
-fi
-
-if [ "$verify" == "true" ]; then
-    echo "--> Verifying tags..."
-    KEYRING_DIR_GIT="$BUILDER_DIR/keyrings/git/$(basename "$REPO")"
-    export KEYRING_DIR_GIT
-    if ! "$(dirname "$0")/verify-git-tag" $REPO $VERIFY_REF; then
-        # if verfication failed, remove fetched content to make sure we'll not
-        # use it
-        if [ "$fresh_clone" -eq 1 ]; then
-            rm -rf "$REPO"
-        else
-            rm -f "$REPO"/.git/FETCH_HEAD
-        fi
-        exit 1
+echo "--> Verifying tags..."
+KEYRING_DIR_GIT="$BUILDER_DIR/keyrings/git/${REPO##*/}"
+export KEYRING_DIR_GIT
+if ! { VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") &&
+    "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; } then
+    # if verfication failed, remove fetched content to make sure we'll not
+    # use it
+    if "$fresh_clone"; then
+        rm -rf "$REPO"
+    else
+        rm -f "$REPO/.git/FETCH_HEAD"
     fi
+    exit 1
 fi
 
-if [ "$FETCH_ONLY" == "1" ]; then
+if [ "${FETCH_ONLY-}" == "1" ]; then
     exit 0
 fi
 
-CURRENT_BRANCH="$(cd $REPO; git branch | sed -n -e 's/^\* \(.*\)/\1/p')"
-if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" == "HEAD" ]; then
-    pushd $REPO &> /dev/null
+CURRENT_BRANCH="$( git -C "$REPO" branch | sed -n -e 's/^\* \(.*\)/\1/p'; )"
+if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
+    pushd "$REPO" &> /dev/null || exit 1
     red="$(echo -e '\033[1;31m')"
     green="$(echo -e '\033[1;32m')"
     normal="$(echo -e '\033[0;0m')"
-    if [ -n "$(git name-rev --name-only $BRANCH 2> /dev/null)" ]; then
+    if [ -n "$(git name-rev --name-only "$BRANCH" 2> /dev/null)" ]; then
         echo "--> Switching branch from $CURRENT_BRANCH branch to ${green}$BRANCH${normal}"
-        git checkout $BRANCH || exit 1
+        git branch -f "$BRANCH" "$VERIFY_REF" &&
+        git checkout "$BRANCH" || exit 1
     else
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"
-        git checkout FETCH_HEAD -b $BRANCH || exit 1
+        git checkout "$VERIFY_REF" -b $BRANCH || exit 1
     fi
-    popd &> /dev/null
+    popd &> /dev/null || exit 1
 fi
 
-if [ "$VERIFY_REF" == "FETCH_HEAD" ]; then
+if ! "$fresh_clone"; then
     echo "--> Merging..."
-    pushd $REPO &> /dev/null
-    git merge --commit -q FETCH_HEAD
-    popd &> /dev/null
+    git -C "$REPO" -c merge.verifySignatures=no merge --commit -q "$VERIFY_REF"
 fi
 
 echo

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -25,7 +25,7 @@ echo "-> Updating sources for $COMPONENT..."
 echo "--> Fetching from $GIT_INFOS..."
 }
 
-set -euo pipefail
+set -eufo pipefail
 [ "${DEBUG-}" = "1" ] && set -x
 
 # shellcheck source=scripts/common
@@ -100,7 +100,7 @@ fi
 
 echo "--> Verifying tags..."
 KEYRING_DIR_GIT="$BUILDER_DIR/keyrings/git/${REPO##*/}"
-export KEYRING_DIR_GIT
+export KEYRING_DIR_GIT CHECK=signed-tag
 if ! { VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") &&
     "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; } then
     # if verfication failed, remove fetched content to make sure we'll not
@@ -117,9 +117,9 @@ if [ "${FETCH_ONLY-}" == "1" ]; then
     exit 0
 fi
 
-CURRENT_BRANCH="$( git -C "$REPO" branch | sed -n -e 's/^\* \(.*\)/\1/p'; )"
+pushd "$REPO" &> /dev/null || exit 1
+CURRENT_BRANCH="$(exec git branch | sed -n -e 's/^\* \(.*\)/\1/p'; )"
 if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
-    pushd "$REPO" &> /dev/null || exit 1
     red="$(echo -e '\033[1;31m')"
     green="$(echo -e '\033[1;32m')"
     normal="$(echo -e '\033[0;0m')"
@@ -131,16 +131,16 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"
         git checkout "$VERIFY_REF" -b $BRANCH || exit 1
     fi
-    if remote=$(git rev-parse --symbolic-full-name '@{u}') 2>/dev/null; then
-        [[ "$remote" =~ ^refs/remotes/ ]] &&
-        git update-ref -- "$remote" "$VERIFY_REF"
-    fi
-    popd &> /dev/null || exit 1
 fi
 
 if ! "$fresh_clone"; then
     echo "--> Merging..."
-    git -C "$REPO" -c merge.verifySignatures=no merge --commit -q "$VERIFY_REF"
+    git -c merge.verifySignatures=no merge --ff-only --commit -q "$VERIFY_REF"
+    if remote=$(exec git rev-parse --symbolic-full-name '@{u}' "$VERIFY_REF") &&
+        [[ "$remote" =~ ^refs/remotes/ ]]; then
+        git update-ref -- "$remote" "$VERIFY_REF"
+    fi
 fi
 
+popd >/dev/null|| exit 1
 echo

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -131,9 +131,10 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"
         git checkout "$VERIFY_REF" -b $BRANCH || exit 1
     fi
-    remote=$(git rev-parse --symbolic-full-name '@{u}') &&
-    [[ "$remote" =~ ^refs/remotes/ ]] &&
-    git update-ref -- "$remote" "$VERIFY_REF" &&
+    if remote=$(git rev-parse --symbolic-full-name '@{u}') 2>/dev/null; then
+        [[ "$remote" =~ ^refs/remotes/ ]] &&
+        git update-ref -- "$remote" "$VERIFY_REF"
+    fi
     popd &> /dev/null || exit 1
 fi
 

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -116,6 +116,8 @@ elif elementIn "$COMPONENT" $LESS_SECURE_SIGNED_COMMITS_SUFFICIENT; then
     CHECK=signed-tag-or-commit
 fi
 
+VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") || exit
+
 if [ "$verify" = 'false' ]; then
     echo -e '\033[1;31m--> NOT verifying tags\033[0;0m'
     exit 1
@@ -125,8 +127,7 @@ else
     else
         echo "--> Verifying tags..."
     fi
-    if ! { VERIFY_REF=$(git -C "$REPO" rev-parse -q --verify "$VERIFY_REF") &&
-        "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; } then
+    if ! "$BUILDER_DIR/scripts/verify-git-tag" "$REPO" "$VERIFY_REF"; then
         # if verfication failed, remove fetched content to make sure we'll not
         # use it
         if "$fresh_clone"; then

--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -132,7 +132,8 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || [ "$VERIFY_REF" = "HEAD" ]; then
         git checkout "$VERIFY_REF" -b $BRANCH || exit 1
     fi
     remote=$(git rev-parse --symbolic-full-name '@{u}') &&
-    git update-ref -- "$remote" "$VERIFY_REF"
+    [[ "$remote" =~ ^refs/remotes/ ]] &&
+    git update-ref -- "$remote" "$VERIFY_REF" &&
     popd &> /dev/null || exit 1
 fi
 

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -109,7 +109,7 @@ if [ "${tag+x}" != 'x' ]; then
     echo "---> No tag pointing at $REF"
     if content=$(git -c gpg.minTrustLevel=fully verify-commit --raw -- "$REF" 2>&1 >/dev/null) &&
         verify_gpg_output "$content"; then
-        echo "---> $REF is a commit signed by a trusted key ― did the signer forget to add a tag?" 
+        echo "---> $REF is a commit signed by a trusted key ― did the signer forget to add a tag?"
     fi
     exit 1
 elif [ "$VALID_TAG_FOUND" -ne 1 ]; then

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -6,6 +6,7 @@
 #  HEAD
 #  mainstream/master
 # Default ref: HEAD
+: "${KEYRING_DIR_GIT=}" "${NO_CHECK=}" "${DEBUG=}" "${VERBOSE=0}"
 
 [ "$DEBUG" = "1" ] && set -x
 
@@ -46,13 +47,9 @@ if [ -n "$KEYRING_DIR_GIT" ]; then
     gpgconf --kill gpg-agent
 fi
 
-pushd "$1" > /dev/null || exit 2
-
-if [ -n "$2" ]; then
-    REF="$2"
-else
-    REF="HEAD"
-fi
+git_check_trust () {
+    git -c gpg.minTrustLevel=fully "$@"
+}
 
 verify_gpg_output () {
     local "content=$1" newsig_number
@@ -64,15 +61,15 @@ verify_gpg_output () {
 }
 
 verify_tag() {
-    local "tag=$1" "expected_hash=$2" hash
+    local "tag=refs/tags/$1" "expected_hash=$2" hash
     if ! hash="$(git rev-parse -q --verify "$tag^{commit}")"; then
-        echo "---> Failed to get tag hash">&2
+        echo "---> Failed to get tag hash for tag $tag">&2
         return 1
     elif ! [ "$hash" = "$expected_hash" ]; then
-        printf %s\\n "---> Tag has wrong hash (found $hash, expected $expected_hash)">&2
+        echo "---> Tag has wrong hash (found $hash, expected $expected_hash)">&2
         return 1
     fi
-    content=$(git -c gpg.minTrustLevel=fully verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
+    content=$(git_check_trust verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
     if verify_gpg_output "$content"; then
         printf %s\\n "---> Good tag ${tag:10}"
         return 0
@@ -83,10 +80,15 @@ verify_tag() {
 
 VALID_TAG_FOUND=0
 set -eu
-case $REF in
-(-*) echo 'Refs cannot begin with -'>&2; exit 1;;
+
+case $# in
+    (1) expected_hash=$(git rev-parse --verify -q HEAD);;
+    (2) expected_hash=$2;;
+    (*) echo 'USAGE: verify-git-tag directory [revision]'>&2; exit 1;;
 esac
-expected_hash=$REF
+
+pushd "$1" > /dev/null || exit 2
+
 if [ "${#expected_hash}" -ne 40 ] && [ "${#expected_hash}" -ne 64 ]; then
     echo "---> Bad Git hash value (wrong length); failing" >&2
     exit 1
@@ -95,27 +97,27 @@ elif ! [[ "$expected_hash" =~ ^[a-f0-9]+$ ]]; then
     exit 1
 fi
 
-tags="$(git tag "--points-at=$REF"|head -c 500)" || exit 1
+unset tags tag
+tags="$(git tag "--points-at=$expected_hash"|head -c 500)" || exit 1
 for tag in $tags; do
-    tag="refs/tags/$tag"
     if verify_tag "$tag" "$expected_hash"; then
         VALID_TAG_FOUND=1
-    elif [ "0${VERBOSE-}" -ge 1 ]; then
+    elif [ "0$VERBOSE" -ge 1 ]; then
         echo "---> One of signed tag cannot be verified: $tag"
     fi
 done
 
-if [ "${tag+x}" != 'x' ]; then
-    echo "---> No tag pointing at $REF"
-    if content=$(git -c gpg.minTrustLevel=fully verify-commit --raw -- "$REF" 2>&1 >/dev/null) &&
+if [ -z "${tag+x}" ]; then
+    echo "---> No tag pointing at $expected_hash"
+    if content=$(git_check_trust verify-commit --raw -- "$expected_hash" 2>&1 >/dev/null) &&
         verify_gpg_output "$content"; then
-        echo "---> $REF is a commit signed by a trusted key ― did the signer forget to add a tag?"
+        echo "---> $expected_hash is a commit signed by a trusted key ― did the signer forget to add a tag?"
     fi
     exit 1
 elif [ "$VALID_TAG_FOUND" -ne 1 ]; then
-    echo "No valid signed tag found!"
-    if [ "0${VERBOSE-}" -eq 0 ]; then
-        echo "---> One of invalid tag: $tag"
+    echo "---> No valid signed tag found!"
+    if [ "0$VERBOSE" -eq 0 ]; then
+        echo "---> One invalid tag: $tag"
     fi
     exit 1
 fi

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash --
 
 # Usage: $0 <source-dir> [<ref>]
 # Example refs:
@@ -54,6 +54,15 @@ else
     REF="HEAD"
 fi
 
+verify_gpg_output () {
+    local "content=$1" newsig_number
+    newsig_number=$(printf %s\\n "$content" | grep -c '^\[GNUPG:] NEWSIG') || return 1
+    [ "$newsig_number" = 1 ] && {
+        printf %s\\n "$content" |
+        grep '^\[GNUPG:] TRUST_\(FULLY\|ULTIMATE\) 0 pgp$' >/dev/null
+    }
+}
+
 verify_tag() {
     local "tag=$1" "expected_hash=$2" hash
     if ! hash="$(git rev-parse -q --verify "$tag^{commit}")"; then
@@ -63,12 +72,9 @@ verify_tag() {
         printf %s\\n "---> Tag has wrong hash (found $hash, expected $expected_hash)">&2
         return 1
     fi
-    content=$(git verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
-    newsig_number=$(printf %s\\n "$content" | grep -c '^\[GNUPG:] NEWSIG') || return 1
-    if [ "$newsig_number" = 1 ] && {
-        printf %s\\n "$content" |
-        grep '^\[GNUPG:] TRUST_\(FULLY\|ULTIMATE\)' >/dev/null
-    }; then
+    content=$(git -c gpg.minTrustLevel=fully verify-tag --raw "$tag" 2>&1 >/dev/null) || return 1
+    if verify_gpg_output "$content"; then
+        printf %s\\n "---> Good tag ${tag:10}"
         return 0
     else
         return 1
@@ -80,30 +86,36 @@ set -eu
 case $REF in
 (-*) echo 'Refs cannot begin with -'>&2; exit 1;;
 esac
-expected_hash=$(git rev-parse -q --verify "$REF") || exit 1
+expected_hash=$REF
 if [ "${#expected_hash}" -ne 40 ] && [ "${#expected_hash}" -ne 64 ]; then
-    echo "---> Bad Git hash value; failing" >&2
+    echo "---> Bad Git hash value (wrong length); failing" >&2
+    exit 1
+elif ! [[ "$expected_hash" =~ ^[a-f0-9]+$ ]]; then
+    echo "---> Bad Git hash value (bad character); failing" >&2
     exit 1
 fi
 
-tags="$(git tag "--points-at=$REF")" || exit 1
+tags="$(git tag "--points-at=$REF"|head -c 500)" || exit 1
 for tag in $tags; do
     tag="refs/tags/$tag"
     if verify_tag "$tag" "$expected_hash"; then
         VALID_TAG_FOUND=1
     elif [ "0${VERBOSE-}" -ge 1 ]; then
-        echo "---> One of signed tag cannot be verified:"
-	git tag -v "$tag"
+        echo "---> One of signed tag cannot be verified: $tag"
     fi
 done
 
-if [ "$VALID_TAG_FOUND" -eq 0 ]; then
+if [ "${tag+x}" != 'x' ]; then
+    echo "---> No tag pointing at $REF"
+    if content=$(git -c gpg.minTrustLevel=fully verify-commit --raw -- "$REF" 2>&1 >/dev/null) &&
+        verify_gpg_output "$content"; then
+        echo "---> $REF is a comit signed by a trusted key ― did the signer forget to add a tag?" 
+    fi
+    exit 1
+elif [ "$VALID_TAG_FOUND" -ne 1 ]; then
     echo "No valid signed tag found!"
     if [ "0${VERBOSE-}" -eq 0 ]; then
-        if [ -n "$(git describe "$REF")" ]; then
-            echo "---> One of invalid tag:"
-            git tag -v $(git describe "$REF")
-        fi
+        echo "---> One of invalid tag: $tag"
     fi
     exit 1
 fi

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -126,7 +126,7 @@ if [ -z "${tag+x}" ]; then
     echo "---> No tag pointing at $expected_hash"
     if content=$(git_check_trust verify-commit --raw -- "$expected_hash" 2>&1 >/dev/null) &&
         verify_gpg_output "$content"; then
-        case $check in
+        case $CHECK in
         (signed-tag-or-commit)
             echo "---> $expected_hash does not have a signed tag"
             echo "---> However, it is signed by a trusted key, and \$CHECK is set to $CHECK"

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -109,7 +109,7 @@ if [ "${tag+x}" != 'x' ]; then
     echo "---> No tag pointing at $REF"
     if content=$(git -c gpg.minTrustLevel=fully verify-commit --raw -- "$REF" 2>&1 >/dev/null) &&
         verify_gpg_output "$content"; then
-        echo "---> $REF is a comit signed by a trusted key ― did the signer forget to add a tag?" 
+        echo "---> $REF is a commit signed by a trusted key ― did the signer forget to add a tag?" 
     fi
     exit 1
 elif [ "$VALID_TAG_FOUND" -ne 1 ]; then

--- a/scripts/verify-git-tag
+++ b/scripts/verify-git-tag
@@ -6,21 +6,37 @@
 #  HEAD
 #  mainstream/master
 # Default ref: HEAD
+set -euo pipefail
 : "${KEYRING_DIR_GIT=}" "${NO_CHECK=}" "${DEBUG=}" "${VERBOSE=0}"
+unset GNUPGHOME
+
+case $0 in (/*) dir=${0%/*}/;; (*/*) dir=./${0%/*};; (*) dir=.;; esac
+BUILDER_DIR=$dir/..
+export BUILDER_DIR
 
 [ "$DEBUG" = "1" ] && set -x
 
-# shellcheck source=scripts/common
-source "$BUILDER_DIR/scripts/common"
-
-set -o pipefail
-
-if [ "$NO_CHECK" == "1" ]; then
-    exit 0
+if [ "${NO_CHECK-}" != "" ]; then
+    echo 'Sorry, NO_CHECK is no longer supported'>&2
+    echo 'If you really want to turn of signature checking, use “CHECK=insecure-no-check”'>&2
+    exit 1
 fi
 
+case ${CHECK=signed-tag} in
+(signed-tag|signed-tag-or-commit) :;;
+(insecure-no-check)
+    echo 'Please avoid calling this script if you don’t want signatures checked'>&2
+    exit 1
+    ;;
+(*)
+    printf 'Invalid value for $CHECK: %q\n' "$CHECK">&2
+    exit 1
+    ;;
+esac
+
 if [ -n "$KEYRING_DIR_GIT" ]; then
-    export GNUPGHOME="$(readlink -m "$KEYRING_DIR_GIT")"
+    GNUPGHOME="$(readlink -m "$KEYRING_DIR_GIT")"
+    export GNUPGHOME
     if [ ! -d "$GNUPGHOME" ]; then
         mkdir -p "$GNUPGHOME"
         chmod 700 "$GNUPGHOME"
@@ -32,7 +48,7 @@ if [ -n "$KEYRING_DIR_GIT" ]; then
         gpg --import qubes-developers-keys.asc
         touch "$GNUPGHOME/pubring.gpg"
     fi
-    maintainers=$(env | grep -oP '^ALLOWED_COMPONENTS_[a-fA-F0-9]{40}')
+    maintainers=$(env | grep -oP '^ALLOWED_COMPONENTS_[a-fA-F0-9]{40}') || :
     for maintainer in $maintainers
     do
         allowed_components=("${!maintainer}")
@@ -79,7 +95,6 @@ verify_tag() {
 }
 
 VALID_TAG_FOUND=0
-set -eu
 
 case $# in
     (1) expected_hash=$(git rev-parse --verify -q HEAD);;
@@ -111,7 +126,21 @@ if [ -z "${tag+x}" ]; then
     echo "---> No tag pointing at $expected_hash"
     if content=$(git_check_trust verify-commit --raw -- "$expected_hash" 2>&1 >/dev/null) &&
         verify_gpg_output "$content"; then
-        echo "---> $expected_hash is a commit signed by a trusted key ― did the signer forget to add a tag?"
+        case $check in
+        (signed-tag-or-commit)
+            echo "---> $expected_hash does not have a signed tag"
+            echo "---> However, it is signed by a trusted key, and \$CHECK is set to $CHECK"
+            echo "---> Accepting it anyway"
+            ;;
+        (signed-tag)
+            echo "---> $expected_hash is a commit signed by a trusted key ― did the signer forget to add a tag?"
+            exit 1
+            ;;
+        (*) # not reached
+            echo 'internal error (this is a bug)'>&2
+            exit 1
+            ;;
+        esac
     fi
     exit 1
 elif [ "$VALID_TAG_FOUND" -ne 1 ]; then


### PR DESCRIPTION
This tightens error handling and input validation in both of these
security-critical scripts.  Additionally, they are changed to not dump
the contents of an unsigned tag (which are attacker-controlled) to the
console.