### PR TITLE
Avoid a dialog 1.3 segfault on Fedora 33

### DIFF
--- a/setup
+++ b/setup
@@ -388,10 +388,10 @@ class DialogUI(DefaultUI):
 
     # Initialize a dialog.Dialog instance
     try:
-        dialog = Dialog(dialog=DIALOG)
+        dialog = Dialog(dialog=DIALOG, pass_args_via_file=False)
     except ExecutableNotFound:
         install_deps(['dialog'])
-        dialog = Dialog(dialog=DIALOG)
+        dialog = Dialog(dialog=DIALOG, pass_args_via_file=False)
 
     @classmethod
     def __init__(cls):

--- a/setup
+++ b/setup
@@ -1452,7 +1452,7 @@ class Wizard(Config):
                 """\
                 Do you have ssh access to the repos?
 
-                Select 'Yes' to configure urls to match git or 'No' for https"
+                Select 'Yes' to configure urls to match git or 'No' for https
             """
             ),
         }


### PR DESCRIPTION
Of course, dialog shouldn’t segfault, but this works around the bug.