### PR TITLE
scripts: Avoid using 'git branch --show-current'

### DIFF
--- a/scripts/get-sources
+++ b/scripts/get-sources
@@ -141,7 +141,7 @@ if [ "${FETCH_ONLY-}" == "1" ]; then
 fi
 
 pushd "$REPO" &> /dev/null || exit 1
-CURRENT_BRANCH="$(exec git branch --show-current)"
+CURRENT_BRANCH="$(exec git rev-parse --abbrev-ref HEAD)"
 if [ "$CURRENT_BRANCH" != "$BRANCH" ] || "$fresh_clone"; then
     if [ -z "${NO_COLOR=}" ]; then
         red=$'\033[1;31m' green=$'\033[1;32m' normal=$'\033[0;0m'


### PR DESCRIPTION
The 'show-current' option was introduced in git 2.22. As the standard Fedora
template in Qubes 4.0 still ships version 2.21.3 by default 'make get-sources' 
fails on these systems.

This commit works around this issue by replacing the command for retrieving the
current branch name with one which is also supported by older versions of git.