### PR TITLE
example-configs: drop awesome on R4.1

### DIFF
--- a/example-configs/qubes-os-master.conf
+++ b/example-configs/qubes-os-master.conf
@@ -74,7 +74,6 @@ COMPONENTS ?= \
     desktop-linux-xfce4-xfwm4 \
     desktop-linux-i3 \
     desktop-linux-i3-settings-qubes \
-    desktop-linux-awesome \
     desktop-linux-manager \
     grubby-dummy \
     dummy-psu \


### PR DESCRIPTION
It is known to be broken and it needs update.

Related: QubesOS/qubes-issues#6418