### PR TITLE
feat: BUILDER_PLUGIN provide a cache file for skipping building pkgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,8 @@ clean-rpms:: clean-installer-rpms
 	done
 	@echo 'Cleaning up rpms in $(SRC_DIR)/*/pkgs/*/*/*...'
 	@sudo rm -f $(SRC_DIR)/*/pkgs/*/*/*.rpm || true
+	@find qubes-src -path \*/pkgs/\*.list -delete -print | sed -e 's/^/ removed /'
+	@find qubes-src -path \*/pkgs/\*.build_stamp -delete -print | sed -e 's/^/ removed /'
 
 clean-makefiles = $(filter-out ./Makefile,$(wildcard $(GIT_REPOS:%=%/Makefile)))
 clean-tgt = $(filter-out linux-template-builder.clean,$(clean-makefiles:$(SRC_DIR)/%/Makefile=%.clean))

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -176,7 +176,7 @@ prepare-chroot: generic-prepare-chroot dist-prepare-chroot
 
 .PHONY: all
 ifneq (,$(PACKAGE_LIST))
-all: prepare-chroot prep copy-in packages
+all: packages
 else ifeq (2,$(VERBOSE))
 # Do nothing if no packages to compile
 all:
@@ -211,7 +211,9 @@ packages:
 	done
 
 .PHONY: rebuild-package
-rebuild-package: | dist-build-dep dist-package dist-copy-out $(SOURCE_COPY_OUT)
+rebuild-package: | prepare-chroot prep copy-in
+rebuild-package: | dist-build-dep dist-package
+rebuild-package: | dist-copy-out $(SOURCE_COPY_OUT)
 
 $(BUILD_STAMP_FILE) : $(shell git -C $(ORIG_SRC) ls-files -- |sed -e 's# #\\ #g' -e 's#^#$(ORIG_SRC)/#')
 	$(info  -> Building packages for $(COMPONENT)/pkgs/$(PACKAGE_SET)-$(DIST) from $(PACKAGE))

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -49,6 +49,8 @@ BUILDER_REPO_DIR = $(PWD)/qubes-packages-mirror-repo/$(PACKAGE_SET)-$(DIST)
 
 OUTPUT_DIR = pkgs/$(PACKAGE_SET)-$(DIST)
 
+BUILD_STAMP_FILE = $(ORIG_SRC)/$(OUTPUT_DIR)/$(notdir $(PACKAGE)).build_stamp
+
 # build environment
 CHROOT_DIR = $(PWD)/chroot-$(PACKAGE_SET)-$(DIST)
 CACHEDIR = $(PWD)/cache/$(DIST)
@@ -208,8 +210,18 @@ packages:
 		fi;\
 	done
 
+.PHONY: rebuild-package
+rebuild-package: | dist-build-dep dist-package dist-copy-out $(SOURCE_COPY_OUT)
+
+$(BUILD_STAMP_FILE) : $(addprefix $(ORIG_SRC)/,$(shell git -C $(ORIG_SRC) ls-files))
+	$(info  -> Building packages for $(COMPONENT)/pkgs/$(PACKAGE_SET)-$(DIST) from $(PACKAGE))
+	rm -f $@
+	$(MAKE) -f $(THIS_MAKEFILE) PACKAGE=$(PACKAGE) rebuild-package
+	touch $@
+
 .PHONY: package
-package: dist-build-dep dist-package dist-copy-out $(SOURCE_COPY_OUT)
+package: $(BUILD_STAMP_FILE)
+	$(info  -> Ready $(COMPONENT)/pkgs/$(DIST)-$(PACKAGE_SET) from $(PACKAGE))
 
 # Returns variable value
 # Example usage: GET_VAR=DISTS_VM make get-var

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -213,7 +213,7 @@ packages:
 .PHONY: rebuild-package
 rebuild-package: | dist-build-dep dist-package dist-copy-out $(SOURCE_COPY_OUT)
 
-$(BUILD_STAMP_FILE) : $(addprefix $(ORIG_SRC)/,$(shell git -C $(ORIG_SRC) ls-files))
+$(BUILD_STAMP_FILE) : $(shell git -C $(ORIG_SRC) ls-files -- |sed -e 's# #\\ #g' -e 's#^#$(ORIG_SRC)/#')
 	$(info  -> Building packages for $(COMPONENT)/pkgs/$(PACKAGE_SET)-$(DIST) from $(PACKAGE))
 	rm -f $@
 	$(MAKE) -f $(THIS_MAKEFILE) PACKAGE=$(PACKAGE) rebuild-package


### PR DESCRIPTION
The `changed-files` script makes sure that the `CACHE_FILE` target is
rebuild each time the source code changes.
