### PR TITLE
Export proxy environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ DIST_DOM0 ?= fc20
 DISTS_VM ?= fc20
 VERBOSE ?= 0
 
+http_proxy := $(REPO_PROXY)
+https_proxy := $(REPO_PROXY)
+ALL_PROXY := $(REPO_PROXY)
+
 # Beware of build order
 COMPONENTS ?= builder
 


### PR DESCRIPTION
It is much better to centralize their handling in the top-level
Makefile, rather than having to modify every sub-Makefile.