### PR TITLE
Add suid option to remount

### DIFF
--- a/scripts/remount
+++ b/scripts/remount
@@ -7,4 +7,4 @@ fi
 
 mountpoint=$($(dirname $0)/find-mount-point "$1")
 set -x
-sudo mount "$mountpoint" -o dev,remount
+sudo mount "$mountpoint" -o dev,suid,remount


### PR DESCRIPTION
Arch template and package builds failed with the 'sudo: effective uid is not 0'.
This addresses part of:
 - https://github.com/QubesOS/qubes-issues/issues/7098
 - https://github.com/Qubes-Community/Contents/issues/153
 - workaround in the archlinux doc https://github.com/Qubes-Community/Contents/blob/master/docs/building/building-archlinux-template.md#sudo-effective-uid-is-not-0