### PR TITLE
Update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifdef GIT_SUBDIR
 endif
 
 # checking for make from Makefile is pointless
-DEPENDENCIES ?= git rpmdevtools rpm-build python3-sh wget perl-Digest-MD5 perl-Digest-SHA
+DEPENDENCIES ?= git rpmdevtools rpm-build python3-sh wget perl-Digest-MD5 perl-Digest-SHA systemd-container
 
 # we add specific distro dependencies due to not common
 # set of packages available like 'createrepo' and 'createrepo_c'


### PR DESCRIPTION
https://github.com/QubesOS/qubes-builder-archlinux/commit/5785684fbfe7f2b1174a31d8991309d7b86d128c introduces the systemd-nspawn command, which is not available unless you install the systemd-container package [https://wiki.debian.org/nspawn]. This dependency was added to ensure the build process works smoothly.
Fixes https://github.com/QubesOS/qubes-issues/issues/7180