### PR TITLE
Fix order of xdotool for r-4.0 and r-4.1 builds

### DIFF
--- a/example-configs/qubes-os-master.conf
+++ b/example-configs/qubes-os-master.conf
@@ -84,6 +84,7 @@ COMPONENTS ?= \
     linux-pvgrub2 \
     linux-gbulb \
     linux-scrypt \
+    xdotool \
     linux-template-builder \
     installer-qubes-os \
     qubes-release \
@@ -100,7 +101,6 @@ COMPONENTS ?= \
     antievilmaid \
     xscreensaver \
     remote-support \
-    xdotool \
     builder \
     builder-debian \
     builder-rpm

--- a/example-configs/qubes-os-r4.0.conf
+++ b/example-configs/qubes-os-r4.0.conf
@@ -81,6 +81,7 @@ COMPONENTS ?= \
     linux-pvgrub2 \
     linux-gbulb \
     linux-scrypt \
+    xdotool \
     linux-template-builder \
     installer-qubes-os \
     linux-yum \
@@ -88,7 +89,6 @@ COMPONENTS ?= \
     antievilmaid \
     xscreensaver \
     dist-upgrade \
-    xdotool \
     builder \
     builder-debian \
     builder-rpm


### PR DESCRIPTION
linux-template-builder requires xdotool rpms to build

I'm not sure if r-4.0 requires xdotool for linux-template-builder, but I got errors while trying to build r-4.1 saying that xdotool's rpms cannot be found.