### PR TITLE
Harden qubesbuilder.* against timing attacks

### DIFF
--- a/rpc-services/qubesbuilder.CopyTemplateBack
+++ b/rpc-services/qubesbuilder.CopyTemplateBack
@@ -5,11 +5,18 @@ set -exo pipefail
 
 read -r -n 1024 attach_key
 [[ "${#attach_key}" -lt 1024 ]]
+hashed_key=$(printf %s "$attach_key" | sha256sum)
+[[ "${#hashed_key}" -eq 67 ]]
+[[ "${hashed_key:64}" = '  -' ]]
+hashed_key=${hashed_key:0:64}
 
 dir=
-while read key path; do
-    if [ "x$attach_key" == "x$key" ]; then
-        dir="$path"
-    fi
-done < /tmp/qubesbuilder.allowedtransfers
-[ -n "$dir" ] && exec tar xkzS -C "$dir" root.img untrusted_appmenus template.conf
+{
+    flock -n 0 --shared
+    while read key path; do
+        if [ "x$attach_key" = "x$hashed_key" ]; then
+            dir="$path"
+        fi
+    done
+} < /tmp/qubesbuilder.allowedtransfers
+[ -n "$dir" ] && exec tar -xkzS -C "$dir" root.img untrusted_appmenus template.conf

--- a/rpc-services/qubesbuilder.ExportDisk
+++ b/rpc-services/qubesbuilder.ExportDisk
@@ -13,7 +13,7 @@ read -r -n 1024 path
 [[ "${#path}" -lt 1024 ]]
 
 if [ -z "$key" ]; then
-    key=$( head -c 20 /dev/urandom | xxd -p )
+    key=$( head -c 256 /dev/urandom | xxd -p -c0 )
     key_is_generated=1
 else
     key_is_generated=

--- a/scripts/build_full_template_in_dispvm
+++ b/scripts/build_full_template_in_dispvm
@@ -80,31 +80,44 @@ copyBuilder() {
 }
 
 allowIncomingTemplateCopy() {
-    key=$1
-    dir=$2
-
-    echo "$key $dir" >> /tmp/qubesbuilder.allowedtransfers
+    local hash dir
+    hash=$1 dir=$2
+    {
+        flock -n 1 -x && echo "$hash $dir"
+    } >> /tmp/qubesbuilder.allowedtransfers || exit
 }
 
 disallowIncomingTemplateCopy() {
-    key=$1
-    sed -i -e "/^$key/d" /tmp/qubesbuilder.allowedtransfers
-    if [ -n "$IMAGE_DEV" ]; then
-        sudo losetup -d "$IMAGE_DEV" || true
-    fi
+    local hash
+    {
+        hash=$1
+        flock -n 9
+        sed -i -e "/^$hash/d" /proc/self/fd/9
+        if [ -n "$IMAGE_DEV" ]; then
+            sudo losetup -d "$IMAGE_DEV" || true
+        fi
+    } 9 >>/tmp/qubesbuilder.allowedtransfers
 }
 
 runBuild() {
+    local key hash
     if ! read -r key < <(
         echo $'\n'"${PWD}/${IMAGE_NAME}" | /usr/lib/qubes/qrexec-client-vm dom0 qubesbuilder.ExportDisk
     ) || [ -z "$key" ]; then
         echo "ERROR: dom0 rpc-services must be installed or updated: qubesbuilder.ExportDisk, qubesbuilder.AttachDisk" >&2
         exit 1
     fi
+    hash=$(
+        set -o pipefail
+        printf %s "$key" | sha256sum
+    ) || exit
+    [[ "${#hash}" -eq 67 ]] || exit
+    [[ "${hash:64}" = '  -' ]] || exit
+    hash=${hash:0:64}
 
     mkdir -p "$PWD/$SRC_DIR/$TEMPLATE_BUILDER_COMPONENT/qubeized_images/$TEMPLATE_NAME"
-    allowIncomingTemplateCopy "$key" "$PWD/$SRC_DIR/$TEMPLATE_BUILDER_COMPONENT/qubeized_images/$TEMPLATE_NAME"
-    trap "disallowIncomingTemplateCopy $key" ERR
+    allowIncomingTemplateCopy "$hash" "$PWD/$SRC_DIR/$TEMPLATE_BUILDER_COMPONENT/qubeized_images/$TEMPLATE_NAME"
+    trap "disallowIncomingTemplateCopy $hash" ERR
     $QVM_RUN --dispvm "/usr/lib/qubes/qrexec-client-vm dom0 qubesbuilder.AttachDisk /bin/echo $key;
         exec 2>&1;
         echo Waiting for /dev/xvdi;
@@ -127,7 +140,7 @@ runBuild() {
         cp ../../template.conf template.conf;
         ls -l . ../../ untrusted_appmenus/;
         echo \"Build done, sending image back to the $HOSTNAME VM\";
-        /usr/lib/qubes/qrexec-client-vm $HOSTNAME qubesbuilder.CopyTemplateBack /bin/sh -c 'echo $key; exec tar chSz untrusted_appmenus root.img template.conf';
+        /usr/lib/qubes/qrexec-client-vm $HOSTNAME qubesbuilder.CopyTemplateBack /bin/sh -c 'echo $key; exec tar -chSz untrusted_appmenus root.img template.conf';
         cd /;
         sudo umount /mnt/removable"
     disallowIncomingTemplateCopy "$key"


### PR DESCRIPTION
This hardens the qubesbuilder.* services against timing attacks by
ensuring that an untrusted string is never compared with a sensitive
string.  Instead, both are hashed first.  Not tested!
