### PR TITLE
Added dependency to which for rpm bases systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ DEPENDENCIES ?= git rpmdevtools rpm-build python3-sh wget perl-Digest-MD5 perl-D
 
 # we add specific distro dependencies due to not common
 # set of packages available like 'createrepo' and 'createrepo_c'
-DEPENDENCIES.rpm ?= createrepo_c
+DEPENDENCIES.rpm ?= createrepo_c which
 DEPENDENCIES.dpkg ?= createrepo
 
 ifneq (1,$(NO_SIGN))


### PR DESCRIPTION
`make qubes` does not work without `which` installed when building fc32

```
Currently installed dependencies:
createrepo_c-0.20.1-1.fc36.x86_64
createrepo_c-0.20.1-1.fc36.x86_64
debootstrap-1.0.127-1.fc36.noarch
devscripts-2.22.1-1.fc36.x86_64
dialog-1.3-41.20220117.fc36.x86_64
dpkg-dev-1.21.9-1.fc36.noarch
git-2.37.3-1.fc36.x86_64
perl-Digest-MD5-2.58-479.fc36.x86_64
perl-Digest-SHA-6.03-1.fc36.x86_64
python3-pyyaml-6.0-3.fc36.x86_64
python3-sh-1.14.2-4.fc36.noarch
rpm-build-4.17.1-3.fc36.x86_64
rpmdevtools-9.6-1.fc36.noarch
systemd-container-250.8-1.fc36.x86_64
make[1]: Entering directory '/home/user/qubes-builder'
-> Preparing fc32 build environment
/home/user/qubes-builder/qubes-src/builder-rpm/update-local-repo.sh: line 11: which: command not found
/home/user/qubes-builder/qubes-src/builder-rpm/update-local-repo.sh: line 17: -q: command not found
make[1]: *** [/home/user/qubes-builder/qubes-src/builder-rpm/Makefile-legacy.rpmbuilder:37: /home/user/qubes-builder/chroot-dom0-fc32/home/user/.prepared_base] Error 1
make[1]: Leaving directory '/home/user/qubes-builder'
make: *** [Makefile:273: vmm-xen-dom0] Error 1
[user@8c88f4752c39 qubes-builder]$ which
bash: which: command not found
```